### PR TITLE
Lazily creating the FLEXWindow when it's actually needed.

### DIFF
--- a/Classes/Explorer Toolbar/FLEXManager.m
+++ b/Classes/Explorer Toolbar/FLEXManager.m
@@ -50,14 +50,22 @@
     if (!_explorerWindow) {
         _explorerWindow = [[FLEXWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
         _explorerWindow.eventDelegate = self;
-        
-        self.explorerViewController = [[FLEXExplorerViewController alloc] init];
-        self.explorerViewController.delegate = self;
+
         _explorerWindow.rootViewController = self.explorerViewController;
         [_explorerWindow addSubview:self.explorerViewController.view];
     }
     
     return _explorerWindow;
+}
+
+- (FLEXExplorerViewController *)explorerViewController
+{
+    if (!_explorerViewController) {
+        _explorerViewController = [[FLEXExplorerViewController alloc] init];
+        _explorerViewController.delegate = self;
+    }
+
+    return _explorerViewController;
 }
 
 - (void)showExplorer


### PR DESCRIPTION
This allows users of `FLEXManager` to use the `-registerGlobalEntryWithName:objectFutureBlock:` API in a `+load` method of their app. Right now that creates the `UIWindow` object when `UIKit` is not ready. With this change, the window will be created the first time you call `-showExplorer`, which would also help a bit with launch times in apps that have FLEX because creating that object would be delayed from app launch to the first time it's used.
