### PR TITLE
[BUG FIX] fix iOS8 load all classes failed

### DIFF
--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -90,7 +90,7 @@
 
 + (NSString *)applicationImageName
 {
-    return [[[NSProcessInfo processInfo] arguments] objectAtIndex:0];
+    return [[NSBundle mainBundle] executablePath];
 }
 
 + (NSString *)applicationName


### PR DESCRIPTION
The old way works well on simulator in both iOS7 and iOS8. But it doesn't work when we use device in iOS8.
I changed into another way, which I've tested on simulators (iOS7 and iOS8) and devices (iOS7 and iOS8)
