### PR TITLE
Added ability to add UIViewController based user defined global entries.

### DIFF
--- a/Classes/Explorer Toolbar/FLEXManager.h
+++ b/Classes/Explorer Toolbar/FLEXManager.h
@@ -23,9 +23,18 @@
 /// @param entryName The string to be displayed in the cell.
 /// @param objectFutureBlock When you tap on the row, information about the object returned by this block will be displayed.
 /// Passing a block that returns an object allows you to display information about an object whose actual pointer may change at runtime (e.g. +currentUser)
+/// @param forceObjectExplorer Specifies how to interpret object returned from objectFutureBlock. If YES it will create object/class inspector view controller
+/// for any supplied object, while NO will cause any passed UIViewController subclasses to be pushed into manager's navigation view controller.
 /// @note This method must be called from the main thread.
 /// The objectFutureBlock will be invoked from the main thread and may return nil.
 /// @note The passed block will be copied and retain for the duration of the application, you may want to use __weak references.
+- (void)registerGlobalEntryWithName:(NSString *)entryName
+                  objectFutureBlock:(id (^)(void))objectFutureBlock
+                forceObjectExplorer:(BOOL)forceObjectExplorer;
+
+/**
+ *  The same as -registerGlobalEntryWithName:objectFutureBlock:forceObjectExplorer: passing YES for forceObjectExplorer.
+ */
 - (void)registerGlobalEntryWithName:(NSString *)entryName objectFutureBlock:(id(^)(void))objectFutureBlock;
 
 @end

--- a/Classes/Explorer Toolbar/FLEXManager.h
+++ b/Classes/Explorer Toolbar/FLEXManager.h
@@ -23,18 +23,18 @@
 /// @param entryName The string to be displayed in the cell.
 /// @param objectFutureBlock When you tap on the row, information about the object returned by this block will be displayed.
 /// Passing a block that returns an object allows you to display information about an object whose actual pointer may change at runtime (e.g. +currentUser)
-/// @param forceObjectExplorer Specifies how to interpret object returned from objectFutureBlock. If YES it will create object/class inspector view controller
-/// for any supplied object, while NO will cause any passed UIViewController subclasses to be pushed into manager's navigation view controller.
 /// @note This method must be called from the main thread.
 /// The objectFutureBlock will be invoked from the main thread and may return nil.
 /// @note The passed block will be copied and retain for the duration of the application, you may want to use __weak references.
-- (void)registerGlobalEntryWithName:(NSString *)entryName
-                  objectFutureBlock:(id (^)(void))objectFutureBlock
-                forceObjectExplorer:(BOOL)forceObjectExplorer;
+- (void)registerGlobalEntryWithName:(NSString *)entryName objectFutureBlock:(id (^)(void))objectFutureBlock;
 
-/**
- *  The same as -registerGlobalEntryWithName:objectFutureBlock:forceObjectExplorer: passing YES for forceObjectExplorer.
- */
-- (void)registerGlobalEntryWithName:(NSString *)entryName objectFutureBlock:(id(^)(void))objectFutureBlock;
+/// Adds an entry at the bottom of the list of Global State items. Call this method before this view controller is displayed.
+/// @param entryName The string to be displayed in the cell.
+/// @param viewControllerFutureBlock When you tap on the row, view controller returned by this block will be pushed on the navigation controller stack.
+/// @note This method must be called from the main thread.
+/// The viewControllerFutureBlock will be invoked from the main thread and may not return nil.
+/// @note The passed block will be copied and retain for the duration of the application, you may want to use __weak references.
+- (void)registerGlobalEntryWithName:(NSString *)entryName
+          viewControllerFutureBlock:(UIViewController * (^)(void))viewControllerFutureBlock;
 
 @end

--- a/Classes/Explorer Toolbar/FLEXManager.m
+++ b/Classes/Explorer Toolbar/FLEXManager.m
@@ -12,7 +12,6 @@
 #import "FLEXGlobalsTableViewControllerEntry.h"
 #import "FLEXObjectExplorerFactory.h"
 #import "FLEXObjectExplorerViewController.h"
-#import <objc/runtime.h>
 
 @interface FLEXManager () <FLEXWindowEventDelegate, FLEXExplorerViewControllerDelegate>
 

--- a/Example/UICatalog/AAPLCatalogTableTableViewController.m
+++ b/Example/UICatalog/AAPLCatalogTableTableViewController.m
@@ -63,12 +63,11 @@
 
 
 
-    // return it in objectFutureBlock
+    // return it in viewControllerFutureBlock
     [[FLEXManager sharedManager] registerGlobalEntryWithName:@"Custom superpowers"
-                                           objectFutureBlock:^id{
-                                               return viewController;
-                                           }
-                                         forceObjectExplorer:NO];
+                                   viewControllerFutureBlock:^id{
+                                       return viewController;
+                                   }];
 }
 
 @end

--- a/Example/UICatalog/AAPLCatalogTableTableViewController.m
+++ b/Example/UICatalog/AAPLCatalogTableTableViewController.m
@@ -12,7 +12,7 @@
 #endif
 
 @interface AAPLCatalogTableTableViewController ()
-
+- (void)registerViewControllerBasedOption;
 @end
 
 @implementation AAPLCatalogTableTableViewController
@@ -22,6 +22,7 @@
     [super viewDidLoad];
     
 #if DEBUG
+    [self registerViewControllerBasedOption];
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"FLEX" style:UIBarButtonItemStylePlain target:self action:@selector(flexButtonTapped:)];
 #endif
 }
@@ -32,6 +33,42 @@
     // This call shows the FLEX toolbar if it's not already shown.
     [[FLEXManager sharedManager] showExplorer];
 #endif
+}
+
+- (void)registerViewControllerBasedOption
+{
+    // create UIViewController subclass
+    UIViewController *viewController = [[UIViewController alloc] init];
+
+    // fill it with some stuff
+    UILabel *infoLabel = [[UILabel alloc] init];
+    infoLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    infoLabel.text = @"Add switches, notes or whatewer you wish to provide your testers with superpowers!";
+    infoLabel.numberOfLines = 0;
+    infoLabel.textAlignment = NSTextAlignmentCenter;
+
+    UIView *view = viewController.view;
+    view.backgroundColor = [UIColor whiteColor];
+    [view addSubview:infoLabel];
+
+    [view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[infoLabel]-0-|"
+                                                                 options:0
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(infoLabel)]];
+
+    [view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[infoLabel]-0-|"
+                                                                 options:0
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(infoLabel)]];
+
+
+
+    // return it in objectFutureBlock
+    [[FLEXManager sharedManager] registerGlobalEntryWithName:@"Custom superpowers"
+                                           objectFutureBlock:^id{
+                                               return viewController;
+                                           }
+                                         forceObjectExplorer:NO];
 }
 
 @end


### PR DESCRIPTION
Makes possible to provide custom UIViewController for user defined global entry, which will be pushed on to the FLEX manager's navigation view controller stack instead of explorer view controller. This could be used to add some custom UI for testers, add different switches/notes, for example network stubbing could be toggled from such custom UI.