### PR TITLE
Add rename and delete operations to file browser.

### DIFF
--- a/Classes/Global State Explorers/FLEXFileBrowserFileOperationController.h
+++ b/Classes/Global State Explorers/FLEXFileBrowserFileOperationController.h
@@ -1,0 +1,33 @@
+//
+//  FLEXFileBrowserFileOperationController.h
+//  Flipboard
+//
+//  Created by Daniel Rodriguez Troitino on 2/13/15.
+//  Copyright (c) 2015 Flipboard. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol FLEXFileBrowserFileOperationController;
+
+@protocol FLEXFileBrowserFileOperationControllerDelegate <NSObject>
+
+- (void)fileOperationControllerDidDismiss:(id<FLEXFileBrowserFileOperationController>)controller;
+
+@end
+
+@protocol FLEXFileBrowserFileOperationController <NSObject>
+
+@property (nonatomic, weak) id<FLEXFileBrowserFileOperationControllerDelegate> delegate;
+
+- (instancetype)initWithPath:(NSString *)path;
+
+- (void)show;
+
+@end
+
+@interface FLEXFileBrowserFileDeleteOperationController : NSObject <FLEXFileBrowserFileOperationController>
+@end
+
+@interface FLEXFileBrowserFileRenameOperationController : NSObject <FLEXFileBrowserFileOperationController>
+@end

--- a/Classes/Global State Explorers/FLEXFileBrowserFileOperationController.m
+++ b/Classes/Global State Explorers/FLEXFileBrowserFileOperationController.m
@@ -1,0 +1,137 @@
+//
+//  FLEXFileBrowserFileOperationController.m
+//  Flipboard
+//
+//  Created by Daniel Rodriguez Troitino on 2/13/15.
+//  Copyright (c) 2015 Flipboard. All rights reserved.
+//
+
+#import "FLEXFileBrowserFileOperationController.h"
+
+@interface FLEXFileBrowserFileDeleteOperationController () <UIAlertViewDelegate>
+
+@property (nonatomic, copy, readonly) NSString *path;
+
+@end
+
+@implementation FLEXFileBrowserFileDeleteOperationController
+
+@synthesize delegate = _delegate;
+
+- (instancetype)init
+{
+    return [self initWithPath:nil];
+}
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super init];
+    if (self) {
+        _path = path;
+    }
+
+    return self;
+}
+
+- (void)show
+{
+    BOOL isDirectory = NO;
+    BOOL stillExists = [[NSFileManager defaultManager] fileExistsAtPath:self.path isDirectory:&isDirectory];
+
+    if (stillExists) {
+        UIAlertView *deleteWarning = [[UIAlertView alloc]
+                                      initWithTitle:[NSString stringWithFormat:@"Delete %@?", self.path.lastPathComponent]
+                                      message:[NSString stringWithFormat:@"The %@ will be deleted. This operation cannot be undone", isDirectory ? @"directory" : @"file"]
+                                      delegate:self
+                                      cancelButtonTitle:@"Cancel"
+                                      otherButtonTitles:@"Delete", nil];
+        [deleteWarning show];
+    } else {
+        [[[UIAlertView alloc] initWithTitle:@"File Removed" message:@"The file at the specified path no longer exists." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
+    }
+}
+
+#pragma mark - UIAlertViewDelegate
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == alertView.cancelButtonIndex) {
+        // Nothing, just cancel
+    } else if (buttonIndex == alertView.firstOtherButtonIndex) {
+        [[NSFileManager defaultManager] removeItemAtPath:self.path error:NULL];
+    }
+}
+
+- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
+{
+    [self.delegate fileOperationControllerDidDismiss:self];
+}
+
+@end
+
+@interface FLEXFileBrowserFileRenameOperationController () <UIAlertViewDelegate>
+
+@property (nonatomic, copy, readonly) NSString *path;
+
+@end
+
+@implementation FLEXFileBrowserFileRenameOperationController
+
+@synthesize delegate = _delegate;
+
+- (instancetype)init
+{
+    return [self initWithPath:nil];
+}
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super init];
+    if (self) {
+        _path = path;
+    }
+
+    return self;
+}
+
+- (void)show
+{
+    BOOL isDirectory = NO;
+    BOOL stillExists = [[NSFileManager defaultManager] fileExistsAtPath:self.path isDirectory:&isDirectory];
+
+    if (stillExists) {
+        UIAlertView *renameDialog = [[UIAlertView alloc]
+                                     initWithTitle:[NSString stringWithFormat:@"Rename %@?", self.path.lastPathComponent]
+                                     message:nil
+                                     delegate:self
+                                     cancelButtonTitle:@"Cancel"
+                                     otherButtonTitles:@"Rename", nil];
+        renameDialog.alertViewStyle = UIAlertViewStylePlainTextInput;
+        UITextField *textField = [renameDialog textFieldAtIndex:0];
+        textField.placeholder = @"New file name";
+        textField.text = self.path.lastPathComponent;
+        [renameDialog show];
+    } else {
+        [[[UIAlertView alloc] initWithTitle:@"File Removed" message:@"The file at the specified path no longer exists." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
+    }
+}
+
+#pragma mark - UIAlertViewDelegate
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == alertView.cancelButtonIndex) {
+        // Nothing, just cancel
+    } else if (buttonIndex == alertView.firstOtherButtonIndex) {
+        NSString *newFileName = [alertView textFieldAtIndex:0].text;
+        NSString *newPath = [[self.path stringByDeletingLastPathComponent] stringByAppendingPathComponent:newFileName];
+        [[NSFileManager defaultManager] moveItemAtPath:self.path toPath:newPath error:NULL];
+    }
+}
+
+- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
+{
+    [self.delegate fileOperationControllerDidDismiss:self];
+}
+
+@end

--- a/Example/UICatalog.xcodeproj/project.pbxproj
+++ b/Example/UICatalog.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		535682BE18F3670300BAAD62 /* AAPLWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 535682A418F3670300BAAD62 /* AAPLWebViewController.m */; };
 		535682BF18F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m in Sources */ = {isa = PBXBuildFile; fileRef = 535682A618F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m */; };
 		53874F9918F36B1800510922 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 53874F9718F36B1800510922 /* Localizable.strings */; };
+		65F8DC6C1A8F11020076F87B /* FLEXFileBrowserFileOperationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F8DC6B1A8F11020076F87B /* FLEXFileBrowserFileOperationController.m */; };
 		943203FE1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 943203FD1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m */; };
 		944F7489197B458C009AB039 /* FLEXArrayExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 944F7426197B458C009AB039 /* FLEXArrayExplorerViewController.m */; };
 		944F748A197B458C009AB039 /* FLEXClassExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 944F7428197B458C009AB039 /* FLEXClassExplorerViewController.m */; };
@@ -165,6 +166,8 @@
 		535682A518F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+AAPLApplicationSpecific.h"; sourceTree = "<group>"; };
 		535682A618F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+AAPLApplicationSpecific.m"; sourceTree = "<group>"; };
 		53874F9818F36B1800510922 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		65F8DC6A1A8F11020076F87B /* FLEXFileBrowserFileOperationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXFileBrowserFileOperationController.h; sourceTree = "<group>"; };
+		65F8DC6B1A8F11020076F87B /* FLEXFileBrowserFileOperationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXFileBrowserFileOperationController.m; sourceTree = "<group>"; };
 		943203FC1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AAPLCatalogTableTableViewController.h; sourceTree = "<group>"; };
 		943203FD1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AAPLCatalogTableTableViewController.m; sourceTree = "<group>"; };
 		944F7425197B458C009AB039 /* FLEXArrayExplorerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArrayExplorerViewController.h; sourceTree = "<group>"; };
@@ -563,6 +566,8 @@
 				944F7475197B458C009AB039 /* FLEXClassesTableViewController.m */,
 				944F7476197B458C009AB039 /* FLEXFileBrowserTableViewController.h */,
 				944F7477197B458C009AB039 /* FLEXFileBrowserTableViewController.m */,
+				65F8DC6A1A8F11020076F87B /* FLEXFileBrowserFileOperationController.h */,
+				65F8DC6B1A8F11020076F87B /* FLEXFileBrowserFileOperationController.m */,
 				0149BFE0198FAFC700B90A1B /* FLEXFileBrowserSearchOperation.h */,
 				0149BFE1198FAFC700B90A1B /* FLEXFileBrowserSearchOperation.m */,
 				944F7478197B458C009AB039 /* FLEXGlobalsTableViewController.h */,
@@ -721,6 +726,7 @@
 				944F74B3197B458C009AB039 /* FLEXLiveObjectsTableViewController.m in Sources */,
 				944F748E197B458C009AB039 /* FLEXImageExplorerViewController.m in Sources */,
 				944F74B6197B458C009AB039 /* FLEXHierarchyTableViewController.m in Sources */,
+				65F8DC6C1A8F11020076F87B /* FLEXFileBrowserFileOperationController.m in Sources */,
 				535682BC18F3670300BAAD62 /* AAPLTextViewController.m in Sources */,
 				944F74B4197B458C009AB039 /* FLEXWebViewController.m in Sources */,
 				944F74A5197B458C009AB039 /* FLEXFieldEditorViewController.m in Sources */,


### PR DESCRIPTION
A long press in any file or directory in the file browser will show a menu with options to rename or delete the selected file or directory.

Renames show an alert view with a text field to write the new name for the file or directory.

Deletes show an alert to confirm the deletion of the file.

Some modifications to the main file browser VC have been done to reload the table view sources after the changes.