### PR TITLE
Add editor for NSDate values.

### DIFF
--- a/Classes/Editing/Argument Input Views/FLEXArgumentInputDateView.h
+++ b/Classes/Editing/Argument Input Views/FLEXArgumentInputDateView.h
@@ -1,0 +1,13 @@
+//
+//  FLEXArgumentInputDataView.h
+//  Flipboard
+//
+//  Created by Daniel Rodriguez Troitino on 2/14/15.
+//  Copyright (c) 2015 Flipboard. All rights reserved.
+//
+
+#import "FLEXArgumentInputView.h"
+
+@interface FLEXArgumentInputDateView : FLEXArgumentInputView
+
+@end

--- a/Classes/Editing/Argument Input Views/FLEXArgumentInputDateView.m
+++ b/Classes/Editing/Argument Input Views/FLEXArgumentInputDateView.m
@@ -1,0 +1,63 @@
+//
+//  FLEXArgumentInputDataView.m
+//  Flipboard
+//
+//  Created by Daniel Rodriguez Troitino on 2/14/15.
+//  Copyright (c) 2015 Flipboard. All rights reserved.
+//
+
+#import "FLEXArgumentInputDateView.h"
+#import "FLEXRuntimeUtility.h"
+
+@interface FLEXArgumentInputDateView ()
+
+@property (nonatomic, strong) UIDatePicker *datePicker;
+
+@end
+
+@implementation FLEXArgumentInputDateView
+
+- (instancetype)initWithArgumentTypeEncoding:(const char *)typeEncoding
+{
+    self = [super initWithArgumentTypeEncoding:typeEncoding];
+    if (self) {
+        self.datePicker = [[UIDatePicker alloc] init];
+        self.datePicker.datePickerMode = UIDatePickerModeDateAndTime;
+        // Using UTC, because that's what the NSDate description prints
+        self.datePicker.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+        self.datePicker.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        [self addSubview:self.datePicker];
+    }
+    return self;
+}
+
+- (void)setInputValue:(id)inputValue
+{
+    if ([inputValue isKindOfClass:[NSDate class]]) {
+        self.datePicker.date = inputValue;
+    }
+}
+
+- (id)inputValue
+{
+    return self.datePicker.date;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.datePicker.frame = self.bounds;
+}
+
+- (CGSize)sizeThatFits:(CGSize)size
+{
+    CGFloat height = [self.datePicker sizeThatFits:size].height;
+    return CGSizeMake(size.width, height);
+}
+
++ (BOOL)supportsObjCType:(const char *)type withCurrentValue:(id)value
+{
+    return (type && (strcmp(type, FLEXEncodeClass(NSDate)) == 0)) || [value isKindOfClass:[NSDate class]];
+}
+
+@end

--- a/Classes/Editing/Argument Input Views/FLEXArgumentInputViewFactory.h
+++ b/Classes/Editing/Argument Input Views/FLEXArgumentInputViewFactory.h
@@ -12,8 +12,11 @@
 
 @interface FLEXArgumentInputViewFactory : NSObject
 
-/// The main factory method for making argument input view subclasses that are the best fit for the type.
+/// Forwards to argumentInputViewForTypeEncoding:currentValue: with a nil currentValue.
 + (FLEXArgumentInputView *)argumentInputViewForTypeEncoding:(const char *)typeEncoding;
+
+/// The main factory method for making argument input view subclasses that are the best fit for the type.
++ (FLEXArgumentInputView *)argumentInputViewForTypeEncoding:(const char *)typeEncoding currentValue:(id)currentValue;
 
 /// A way to check if we should try editing a filed given its type encoding and value.
 /// Useful when deciding whether to edit or explore a property, ivar, or NSUserDefaults value.

--- a/Classes/Editing/Argument Input Views/FLEXArgumentInputViewFactory.m
+++ b/Classes/Editing/Argument Input Views/FLEXArgumentInputViewFactory.m
@@ -16,12 +16,18 @@
 #import "FLEXArgumentInputStringView.h"
 #import "FLEXArgumentInputFontView.h"
 #import "FLEXArgumentInputColorView.h"
+#import "FLEXArgumentInputDateView.h"
 
 @implementation FLEXArgumentInputViewFactory
 
 + (FLEXArgumentInputView *)argumentInputViewForTypeEncoding:(const char *)typeEncoding
 {
-    Class subclass = [self argumentInputViewSubclassForTypeEncoding:typeEncoding currentValue:nil];
+    return [self argumentInputViewForTypeEncoding:typeEncoding currentValue:nil];
+}
+
++ (FLEXArgumentInputView *)argumentInputViewForTypeEncoding:(const char *)typeEncoding currentValue:(id)currentValue
+{
+    Class subclass = [self argumentInputViewSubclassForTypeEncoding:typeEncoding currentValue:currentValue];
     if (!subclass) {
         // Fall back to a FLEXArgumentInputNotSupportedView if we can't find a subclass that fits the type encoding.
         // The unsupported view shows "nil" and does not allow user input.
@@ -47,6 +53,8 @@
         argumentInputViewSubclass = [FLEXArgumentInputStructView class];
     } else if ([FLEXArgumentInputSwitchView supportsObjCType:typeEncoding withCurrentValue:currentValue]) {
         argumentInputViewSubclass = [FLEXArgumentInputSwitchView class];
+    } else if ([FLEXArgumentInputDateView supportsObjCType:typeEncoding withCurrentValue:currentValue]) {
+        argumentInputViewSubclass = [FLEXArgumentInputDateView class];
     } else if ([FLEXArgumentInputNumberView supportsObjCType:typeEncoding withCurrentValue:currentValue]) {
         argumentInputViewSubclass = [FLEXArgumentInputNumberView class];
     } else if ([FLEXArgumentInputJSONObjectView supportsObjCType:typeEncoding withCurrentValue:currentValue]) {

--- a/Classes/Editing/FLEXDefaultEditorViewController.m
+++ b/Classes/Editing/FLEXDefaultEditorViewController.m
@@ -41,10 +41,11 @@
     [super viewDidLoad];
     
     self.fieldEditorView.fieldDescription = self.key;
-    
-    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:@encode(id)];
+
+    id currentValue = [self.defaults objectForKey:self.key];
+    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:@encode(id) currentValue:currentValue];
     inputView.backgroundColor = self.view.backgroundColor;
-    inputView.inputValue = [self.defaults objectForKey:self.key];
+    inputView.inputValue = currentValue;
     self.fieldEditorView.argumentInputViews = @[inputView];
 }
 

--- a/Example/UICatalog.xcodeproj/project.pbxproj
+++ b/Example/UICatalog.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		535682BE18F3670300BAAD62 /* AAPLWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 535682A418F3670300BAAD62 /* AAPLWebViewController.m */; };
 		535682BF18F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m in Sources */ = {isa = PBXBuildFile; fileRef = 535682A618F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m */; };
 		53874F9918F36B1800510922 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 53874F9718F36B1800510922 /* Localizable.strings */; };
+		650855EB1A9007D5006109A1 /* FLEXArgumentInputDateView.m in Sources */ = {isa = PBXBuildFile; fileRef = 650855EA1A9007D5006109A1 /* FLEXArgumentInputDateView.m */; };
 		943203FE1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 943203FD1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m */; };
 		944F7489197B458C009AB039 /* FLEXArrayExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 944F7426197B458C009AB039 /* FLEXArrayExplorerViewController.m */; };
 		944F748A197B458C009AB039 /* FLEXClassExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 944F7428197B458C009AB039 /* FLEXClassExplorerViewController.m */; };
@@ -165,6 +166,8 @@
 		535682A518F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+AAPLApplicationSpecific.h"; sourceTree = "<group>"; };
 		535682A618F3670300BAAD62 /* UIColor+AAPLApplicationSpecific.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+AAPLApplicationSpecific.m"; sourceTree = "<group>"; };
 		53874F9818F36B1800510922 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		650855E91A9007D5006109A1 /* FLEXArgumentInputDateView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputDateView.h; sourceTree = "<group>"; };
+		650855EA1A9007D5006109A1 /* FLEXArgumentInputDateView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputDateView.m; sourceTree = "<group>"; };
 		943203FC1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AAPLCatalogTableTableViewController.h; sourceTree = "<group>"; };
 		943203FD1978F42F00E24DB3 /* AAPLCatalogTableTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AAPLCatalogTableTableViewController.m; sourceTree = "<group>"; };
 		944F7425197B458C009AB039 /* FLEXArrayExplorerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArrayExplorerViewController.h; sourceTree = "<group>"; };
@@ -510,6 +513,8 @@
 			children = (
 				944F7446197B458C009AB039 /* FLEXArgumentInputColorView.h */,
 				944F7447197B458C009AB039 /* FLEXArgumentInputColorView.m */,
+				650855E91A9007D5006109A1 /* FLEXArgumentInputDateView.h */,
+				650855EA1A9007D5006109A1 /* FLEXArgumentInputDateView.m */,
 				944F7448197B458C009AB039 /* FLEXArgumentInputFontView.h */,
 				944F7449197B458C009AB039 /* FLEXArgumentInputFontView.m */,
 				944F744A197B458C009AB039 /* FLEXArgumentInputJSONObjectView.h */,
@@ -743,6 +748,7 @@
 				535682B718F3670300BAAD62 /* AAPLSliderViewController.m in Sources */,
 				944F74AC197B458C009AB039 /* FLEXToolbarItem.m in Sources */,
 				944F74B7197B458C009AB039 /* FLEXImagePreviewViewController.m in Sources */,
+				650855EB1A9007D5006109A1 /* FLEXArgumentInputDateView.m in Sources */,
 				944F7498197B458C009AB039 /* FLEXArgumentInputColorView.m in Sources */,
 				944F74A0197B458C009AB039 /* FLEXArgumentInputTextView.m in Sources */,
 				944F749C197B458C009AB039 /* FLEXArgumentInputNumberView.m in Sources */,


### PR DESCRIPTION
The argument input for dates is an UIDatePicker, set to use gregorian
calendar and UTC time zone (the locale is still the current one).

Unfortunately UIDatePicker doesn’t give an option for showing seconds.

Works in the object explorer and the defaults explorer. The changes
around ArgumentInputViewFactory and DefaultEditorVC allows to introspect
the value for its class and show the right editor (otherwise the JSON
editor is used by default).