### PR TITLE
Fix fileURLOrData passthrough in network observer

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -565,7 +565,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask delegate:(id <NSU
 
         // Call through to the original completion handler
         if (completion) {
-            completion(data, response, error);
+            completion(fileURLOrData, response, error);
         }
     };
     return completionWrapper;


### PR DESCRIPTION
Completion handler may be expecting fileURL so should always pass through the response that the session task gave us.