### PR TITLE
enhance json detect

### DIFF
--- a/Classes/Network/FLEXNetworkTransactionDetailTableViewController.m
+++ b/Classes/Network/FLEXNetworkTransactionDetailTableViewController.m
@@ -400,7 +400,7 @@ typedef UIViewController *(^FLEXNetworkDetailRowSelectionFuture)(void);
 {
     // FIXME (RKO): Don't rely on UTF8 string encoding
     UIViewController *detailViewController = nil;
-    if ([mimeType isEqual:@"application/json"] || [mimeType isEqual:@"application/javascript"] || [mimeType isEqual:@"text/javascript"]) {
+    if ([FLEXUtility isValidJSONData:data]) {
         NSString *prettyJSON = [FLEXUtility prettyJSONStringFromData:data];
         if ([prettyJSON length] > 0) {
             detailViewController = [[FLEXWebViewController alloc] initWithText:prettyJSON];

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -35,6 +35,7 @@
 + (NSString *)statusCodeStringFromURLResponse:(NSURLResponse *)response;
 + (NSDictionary *)dictionaryFromQuery:(NSString *)query;
 + (NSString *)prettyJSONStringFromData:(NSData *)data;
++ (BOOL)isValidJSONData:(NSData *)data;
 + (NSData *)inflatedDataFromCompressedData:(NSData *)compressedData;
 
 @end

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -278,8 +278,13 @@
     } else {
         prettyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
-
+    
     return prettyString;
+}
+
++ (BOOL)isValidJSONData:(NSData *)data
+{
+    return [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] ? YES : NO;
 }
 
 // Thanks to the following links for help with this method


### PR DESCRIPTION
Hello @ryanolsonk,

in some of my case, server return the wrong mime type like "text/html" for json data. I think it will be better using a method `isValidJSONData:` to check it. `prettyJSONStringFromData:` handle only the real json data. how do you feel? thank you.