### PR TITLE
Fix arm64 build

### DIFF
--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -188,6 +188,7 @@
 + (UIImage *)thumbnailedImageWithMaxPixelDimension:(NSInteger)dimension fromImageData:(NSData *)data
 {
     UIImage *thumbnail = nil;
+    #ifndef __LP64__
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, 0);
     if (imageSource) {
         NSDictionary *options = @{ (__bridge id)kCGImageSourceCreateThumbnailWithTransform : @YES,
@@ -201,6 +202,7 @@
         }
         CFRelease(imageSource);
     }
+    #endif
     return thumbnail;
 }
 


### PR DESCRIPTION
Build error:
Undefined symbols for architecture arm64:
  "_kCGImageSourceCreateThumbnailWithTransform", referenced from:
      +[FLEXUtility
thumbnailedImageWithMaxPixelDimension:fromImageData:] in FLEXUtility.o
  "_CGImageSourceCreateWithData", referenced from:
      +[FLEXUtility
thumbnailedImageWithMaxPixelDimension:fromImageData:] in FLEXUtility.o
  "_kCGImageSourceThumbnailMaxPixelSize", referenced from:
      +[FLEXUtility
thumbnailedImageWithMaxPixelDimension:fromImageData:] in FLEXUtility.o
  "_kCGImageSourceCreateThumbnailFromImageAlways", referenced from:
      +[FLEXUtility
thumbnailedImageWithMaxPixelDimension:fromImageData:] in FLEXUtility.o
  "_CGImageSourceCreateThumbnailAtIndex", referenced from:
      +[FLEXUtility
thumbnailedImageWithMaxPixelDimension:fromImageData:] in FLEXUtility.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see
invocation)