### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Once a view is selected, you can tap on the info bar below the toolbar to presen
 ![View Modification](http://engineering.flipboard.com/assets/flex/advanced-view-editing.gif)
 
 ### Network History
-When enabled, network debugging allows you to view all requests made using NSURLConnection or NSURLSession. Settings allow you to adjust what kind of response bodies get cached and the maximum size limit of the response cache. You can choose to have network debugging enabled automatically on app launch. This setting is persisted accross launches.
+When enabled, network debugging allows you to view all requests made using NSURLConnection or NSURLSession. Settings allow you to adjust what kind of response bodies get cached and the maximum size limit of the response cache. You can choose to have network debugging enabled automatically on app launch. This setting is persisted across launches.
 
 ![Network History](http://engineering.flipboard.com/assets/flex/network-history.gif)
 


### PR DESCRIPTION
@Flipboard, I've corrected a typographical error in the documentation of the [FLEX](https://github.com/Flipboard/FLEX) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.