### PR TITLE
- (void)toggle***Tool - It is not necessary to 'dismiss' when 'present'

### DIFF
--- a/Classes/ExplorerToolbar/FLEXExplorerViewController.m
+++ b/Classes/ExplorerToolbar/FLEXExplorerViewController.m
@@ -841,6 +841,7 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     if (viewsModalShown) {
         [self resignKeyAndDismissViewControllerAnimated:YES completion:nil];
     } else {
+        [self dismissPreviousPresentViewController];
         NSArray *allViews = [self allViewsInHierarchy];
         NSDictionary *depthsForViews = [self hierarchyDepthsForViews:allViews];
         FLEXHierarchyTableViewController *hierarchyTVC = [[FLEXHierarchyTableViewController alloc] initWithViews:allViews viewsAtTap:self.viewsAtTapPoint selectedView:self.selectedView depths:depthsForViews];
@@ -857,12 +858,21 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     if (menuModalShown) {
         [self resignKeyAndDismissViewControllerAnimated:YES completion:nil];
     } else {
+        [self dismissPreviousPresentViewController];
         FLEXGlobalsTableViewController *globalsViewController = [[FLEXGlobalsTableViewController alloc] init];
         globalsViewController.delegate = self;
         [FLEXGlobalsTableViewController setApplicationWindow:[[UIApplication sharedApplication] keyWindow]];
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:globalsViewController];
         [self makeKeyAndPresentViewController:navigationController animated:YES completion:nil];
     }
+}
+
+- (BOOL)dismissPreviousPresentViewController{
+    BOOL needDismissBeforePresent = self.previousKeyWindow && (self.previousKeyWindow != [UIApplication sharedApplication].keyWindow);
+    if (needDismissBeforePresent) {
+        [self resignKeyAndDismissViewControllerAnimated:NO completion:nil];
+    }
+    return needDismissBeforePresent;
 }
 
 - (void)handleDownArrowKeyPressed

--- a/Classes/ExplorerToolbar/FLEXExplorerViewController.m
+++ b/Classes/ExplorerToolbar/FLEXExplorerViewController.m
@@ -841,7 +841,6 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     if (viewsModalShown) {
         [self resignKeyAndDismissViewControllerAnimated:YES completion:nil];
     } else {
-        [self resignKeyAndDismissViewControllerAnimated:NO completion:nil];
         NSArray *allViews = [self allViewsInHierarchy];
         NSDictionary *depthsForViews = [self hierarchyDepthsForViews:allViews];
         FLEXHierarchyTableViewController *hierarchyTVC = [[FLEXHierarchyTableViewController alloc] initWithViews:allViews viewsAtTap:self.viewsAtTapPoint selectedView:self.selectedView depths:depthsForViews];
@@ -858,7 +857,6 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     if (menuModalShown) {
         [self resignKeyAndDismissViewControllerAnimated:YES completion:nil];
     } else {
-        [self resignKeyAndDismissViewControllerAnimated:NO completion:nil];
         FLEXGlobalsTableViewController *globalsViewController = [[FLEXGlobalsTableViewController alloc] init];
         globalsViewController.delegate = self;
         [FLEXGlobalsTableViewController setApplicationWindow:[[UIApplication sharedApplication] keyWindow]];


### PR DESCRIPTION
**If always dismiss first before present, then the property `previousKeyWindow` and `previousStatusBarStyle` will be not effective.**


`previousStatusBarStyle` for example:
1. original: white color
![image](https://cloud.githubusercontent.com/assets/7866087/11468817/439edb04-978d-11e5-9a1e-e78d399a3469.png)
2. FLEX presented: black color
![image](https://cloud.githubusercontent.com/assets/7866087/11468830/4f0c44d6-978d-11e5-8dc8-5705ed5a9f40.png)
3. FLEX dismissed: still black color(`previousStatusBarStyle` lose effectiveness)
![image](https://cloud.githubusercontent.com/assets/7866087/11468835/577c163c-978d-11e5-869b-5456af9fa72e.png)