### PR TITLE
*Added the ability to determine a UIView's view controller without selection the view controller's view delegate.

### DIFF
--- a/Classes/ObjectExplorers/FLEXViewExplorerViewController.m
+++ b/Classes/ObjectExplorers/FLEXViewExplorerViewController.m
@@ -15,7 +15,8 @@
 
 typedef NS_ENUM(NSUInteger, FLEXViewExplorerRow) {
     FLEXViewExplorerRowViewController,
-    FLEXViewExplorerRowPreview
+    FLEXViewExplorerRowPreview,
+    FLEXViewExplorerRowViewControllerForAncestor
 };
 
 @interface FLEXViewExplorerViewController ()
@@ -46,6 +47,8 @@ typedef NS_ENUM(NSUInteger, FLEXViewExplorerRow) {
     
     if ([FLEXUtility viewControllerForView:self.viewToExplore]) {
         [rowCookies addObject:@(FLEXViewExplorerRowViewController)];
+    }else{
+        [rowCookies addObject:@(FLEXViewExplorerRowViewControllerForAncestor)];
     }
     
     [rowCookies addObject:@(FLEXViewExplorerRowPreview)];
@@ -79,6 +82,10 @@ typedef NS_ENUM(NSUInteger, FLEXViewExplorerRow) {
             case FLEXViewExplorerRowPreview:
                 title = @"Preview Image";
                 break;
+            
+            case FLEXViewExplorerRowViewControllerForAncestor:
+                title = @"View Controller For Ancestor";
+                break;
         }
     } else if ([rowCookie isKindOfClass:[NSString class]]) {
         objc_property_t property = [self viewPropertyForName:rowCookie];
@@ -104,6 +111,10 @@ typedef NS_ENUM(NSUInteger, FLEXViewExplorerRow) {
                 break;
                 
             case FLEXViewExplorerRowPreview:
+                break;
+            
+            case FLEXViewExplorerRowViewControllerForAncestor:
+                subtitle = [FLEXRuntimeUtility descriptionForIvarOrPropertyValue:[FLEXUtility viewControllerForAncestralView:self.viewToExplore]];
                 break;
         }
     } else if ([rowCookie isKindOfClass:[NSString class]]) {
@@ -140,6 +151,10 @@ typedef NS_ENUM(NSUInteger, FLEXViewExplorerRow) {
                 
             case FLEXViewExplorerRowPreview:
                 drillInViewController = [[self class] imagePreviewViewControllerForView:self.viewToExplore];
+                break;
+                
+            case FLEXViewExplorerRowViewControllerForAncestor:
+                drillInViewController = [FLEXObjectExplorerFactory explorerViewControllerForObject:[FLEXUtility viewControllerForAncestralView:self.viewToExplore]];
                 break;
         }
     } else if ([rowCookie isKindOfClass:[NSString class]]) {

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -18,6 +18,7 @@
 + (NSString *)descriptionForView:(UIView *)view includingFrame:(BOOL)includeFrame;
 + (NSString *)stringForCGRect:(CGRect)rect;
 + (UIViewController *)viewControllerForView:(UIView *)view;
++ (UIViewController *)viewControllerForAncestralView:(UIView *)view;
 + (NSString *)detailDescriptionForView:(UIView *)view;
 + (UIImage *)circularImageWithColor:(UIColor *)color radius:(CGFloat)radius;
 + (UIColor *)scrollViewGrayColor;

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -58,6 +58,18 @@
     return viewController;
 }
 
++ (UIViewController *)viewControllerForAncestralView:(UIView *)view{
+    UIViewController *viewController = nil;
+    SEL viewDelSel = NSSelectorFromString([NSString stringWithFormat:@"%@ewControllerForAncestor", @"_vi"]);
+    if ([view respondsToSelector:viewDelSel]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        viewController = [view performSelector:viewDelSel];
+#pragma clang diagnostic pop
+    }
+    return viewController;
+}
+
 + (NSString *)detailDescriptionForView:(UIView *)view
 {
     return [NSString stringWithFormat:@"frame %@", [self stringForCGRect:view.frame]];


### PR DESCRIPTION
This is more of a convenience thing in most cases. It does become quite useful when debugging parent and child view controllers and is quite helpful (personally) when messing with apps and injecting FLEX using Cydia Substrate. `_viewControllerForAncestor` is quite an old method and has been around since [iOS 4.2 (November 2010)](https://github.com/nst/iOS-Runtime-Headers/blob/4.2/Frameworks/UIKit.framework/UIView.h#L279) so it can be assumed that it is as safe `_viewDelegate` which was introduced in 4.0, I believe. It is, however, more robust in that the view controller can be determined from *any* view contained within a given view controller.

I left the old method as is, even though this new method should be a suitable replacement. I'll leave such changes up to the main contributors' discretion going forward.