### PR TITLE
Added support for password protected databases

### DIFF
--- a/Classes/FLEXManager.h
+++ b/Classes/FLEXManager.h
@@ -49,6 +49,10 @@
 
 #pragma mark - Extensions
 
+/// Default database password is @c nil by default.
+/// Set this to the password you want the databases to open with.
+@property (copy, nonatomic) NSString *defaultDatabasePassword;
+
 /// Adds an entry at the bottom of the list of Global State items. Call this method before this view controller is displayed.
 /// @param entryName The string to be displayed in the cell.
 /// @param objectFutureBlock When you tap on the row, information about the object returned by this block will be displayed.

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDatabaseManager.m
@@ -9,6 +9,7 @@
 
 
 #import "FLEXDatabaseManager.h"
+#import "FLEXManager.h"
 #import <sqlite3.h>
 
 
@@ -38,6 +39,15 @@ static NSString *const QUERY_TABLENAMES_SQL = @"SELECT name FROM sqlite_master W
         return YES;
     }
     int err = sqlite3_open([_databasePath UTF8String], &_db);
+
+    NSString *defaultDatabasePassword = [FLEXManager sharedManager].defaultDatabasePassword;
+
+    if (defaultDatabasePassword) {
+        const char *key = defaultDatabasePassword.UTF8String;
+
+        sqlite3_key(_db, key, (int)strlen(key));
+    }
+
     if(err != SQLITE_OK) {
         NSLog(@"error opening!: %d", err);
         return NO;


### PR DESCRIPTION
Currently, the password is set for every database connection, even if some databases are not password protected.

I think that the check would look something like [this](https://github.com/sqlitebrowser/sqlitebrowser/blob/dd92f160125e04e97c1a16fcd05a8407ddb183db/src/sqlitedb.cpp#L207) and I don't know if it's necessary. It depends on the users' use cases, myself for example have only one database, which is encrypted.