### PR TITLE
Added handling for nil Realm property values

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.m
@@ -101,7 +101,8 @@
     for (RLMObject *result in results) {
         NSMutableDictionary *entry = [NSMutableDictionary dictionary];
         for (RLMProperty *property in objectSchema.properties) {
-            entry[property.name] = [result valueForKey:property.name];
+            id value = [result valueForKey:property.name];
+            entry[property.name] = (value) ? (value) : [NSNull null];
         }
         
         [allDataEntries addObject:entry];


### PR DESCRIPTION
Sorry about this! It appears a bug involving Realm nullability slipped through the cracks!

This PR adds a small check to ensure properties return from a Realm object are not nil, and substitutes an `NSNull` instance if it is to ensure the data is still valid when passed to an `NSArray` down the line.