### PR TITLE
Replaced deprecated 'path' property in Realm configuration

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.m
@@ -52,7 +52,7 @@
     
     NSError *error = nil;
     id configuration = [[configurationClass alloc] init];
-    [(RLMRealmConfiguration *)configuration setPath:self.path];
+    [(RLMRealmConfiguration *)configuration setFileURL:[NSURL fileURLWithPath:self.path]];
     self.realm = [realmClass realmWithConfiguration:configuration error:&error];
     return (error == nil);
 }

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDefines.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDefines.h
@@ -12,7 +12,7 @@
 @class RLMObject, RLMResults, RLMRealm, RLMRealmConfiguration, RLMSchema, RLMObjectSchema, RLMProperty;
 
 @interface RLMRealmConfiguration : NSObject
-@property (nonatomic, copy) NSString *path;
+@property (nonatomic, copy) NSURL *fileURL;
 @end
 
 @interface RLMRealm : NSObject


### PR DESCRIPTION
Following the latest trends in Swift, Realm made the decision to deprecate using strings for file paths in its API in favour of `NSURL`. As of the latest version of Realm, 0.103.0, the deprecated `path` property was completely removed.

As reported in https://github.com/Flipboard/FLEX/issues/127, this pull request updates the integration of Realm in FLEX to use the new NSURL value for file paths.