### PR TITLE
Fix #150.

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -172,7 +172,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask delegate:(id <NSU
             @selector(URLSession:dataTask:didReceiveData:),
             @selector(URLSession:dataTask:didReceiveResponse:completionHandler:),
             @selector(URLSession:task:didCompleteWithError:),
-            @selector(URLSession:dataTask:didBecomeDownloadTask:delegate:),
+            @selector(URLSession:dataTask:didBecomeDownloadTask:),
             @selector(URLSession:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:),
             @selector(URLSession:downloadTask:didFinishDownloadingToURL:)
         };


### PR DESCRIPTION
Use `@selector(URLSession:dataTask:didBecomeDownloadTask:)` instead of `@selector(URLSession:dataTask:didBecomeDownloadTask:delegate:)` in method search.