### PR TITLE
Fix #175

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -147,6 +147,11 @@
         if ([obj2 objectForKey:text] == [NSNull null]) {
             return NSOrderedDescending;
         }
+        
+        if (![[obj1 objectForKey:text] respondsToSelector:@selector(compare:)] && ![[obj2 objectForKey:text] respondsToSelector:@selector(compare:)]) {
+            return NSOrderedSame;
+        }
+        
         NSComparisonResult result =  [[obj1 objectForKey:text] compare:[obj2 objectForKey:text]];
         
         return result;


### PR DESCRIPTION
Adds a check for `respondsToSelector:@selector(compare:)` to prevent a crash if the property corresponding to a column represents something that doesn't respond to `compare:`, e.g. a RLMAccessor. See #175. 