### PR TITLE
Add ability to filter out noisy network requests from being recorded

### DIFF
--- a/Classes/FLEXManager.h
+++ b/Classes/FLEXManager.h
@@ -30,6 +30,12 @@
 /// The response cache uses an NSCache, so it may purge prior to hitting the limit when the app is under memory pressure.
 @property (nonatomic, assign) NSUInteger networkResponseCacheByteLimit;
 
+/// Requests whose host ends with one of the blacklisted entries in this array will be not be recorded (eg. google.com).
+/// Wildcard or subdomain entries are not required (eg. google.com will match any subdomain under google.com).
+/// Useful to remove requests that are typically noisy, such as analytics requests that you aren't interested in tracking.
+@property (nonatomic, copy) NSArray<NSString *> *networkRequestHostBlacklist;
+
+
 #pragma mark - Keyboard Shortcuts
 
 /// Simulator keyboard shortcuts are enabled by default.

--- a/Classes/Manager/FLEXManager.m
+++ b/Classes/Manager/FLEXManager.m
@@ -115,6 +115,14 @@
     [[FLEXNetworkRecorder defaultRecorder] setResponseCacheByteLimit:networkResponseCacheByteLimit];
 }
 
+- (void)setNetworkRequestHostBlacklist:(NSArray<NSString *> *)networkRequestHostBlacklist {
+    [FLEXNetworkRecorder defaultRecorder].hostBlacklist = networkRequestHostBlacklist;
+}
+
+- (NSArray<NSString *> *)hostBlacklist {
+    return [FLEXNetworkRecorder defaultRecorder].hostBlacklist;
+}
+
 #pragma mark - FLEXWindowEventDelegate
 
 - (BOOL)shouldHandleTouchAtPoint:(CGPoint)pointInWindow

--- a/Classes/Network/FLEXNetworkRecorder.h
+++ b/Classes/Network/FLEXNetworkRecorder.h
@@ -27,6 +27,9 @@ extern NSString *const kFLEXNetworkRecorderTransactionsClearedNotification;
 /// If NO, the recorder not cache will not cache response for content types with an "image", "video", or "audio" prefix.
 @property (nonatomic, assign) BOOL shouldCacheMediaResponses;
 
+@property (nonatomic, copy) NSArray<NSString *> *hostBlacklist;
+
+
 // Accessing recorded network activity
 
 /// Array of FLEXNetworkTransaction objects ordered by start time with the newest first.

--- a/Classes/Network/FLEXNetworkRecorder.m
+++ b/Classes/Network/FLEXNetworkRecorder.m
@@ -104,6 +104,12 @@ NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.r
 
 - (void)recordRequestWillBeSentWithRequestID:(NSString *)requestID request:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse
 {
+    for (NSString *host in self.hostBlacklist) {
+        if ([request.URL.host hasSuffix:host]) {
+            return;
+        }
+    }
+    
     NSDate *startDate = [NSDate date];
 
     if (redirectResponse) {


### PR DESCRIPTION
Some network requests can be very noisy and congest the network recorder, such as analytics calls, or other calls you may not be interested in logged. This adds a simple filter to not log any of those requests.
