### PR TITLE
Fixed keyboard shortcuts in Xcode 9 simulator

### DIFF
--- a/Classes/Utility/FLEXKeyboardShortcutManager.m
+++ b/Classes/Utility/FLEXKeyboardShortcutManager.m
@@ -260,7 +260,7 @@ static const long kFLEXCommandKeyCode = 0xe3;
             dispatch_block_t actionBlock = self.actionsForKeyInputs[exactMatch];
             
             if (!actionBlock) {
-                FLEXKeyInput *shiftMatch = [FLEXKeyInput keyInputForKey:modifiedInput flags:flags&(!UIKeyModifierShift)];
+                FLEXKeyInput *shiftMatch = [FLEXKeyInput keyInputForKey:modifiedInput flags:flags&(~UIKeyModifierShift)];
                 actionBlock = self.actionsForKeyInputs[shiftMatch];
             }
             


### PR DESCRIPTION
Pressing Cmd+S in the Simulator normally just takes a screenshot, but in Xcode 9, it also triggers the default "s" keyboard shortcut which enables the FLEX Select tool. This is because the keyboard flags is ANDed with a logical NOT of UIKeyModifierShift instead of the bitwise inverse