### PR TITLE
Simplify view controller presentation code

### DIFF
--- a/Classes/ExplorerInterface/FLEXExplorerViewController.h
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.h
@@ -17,6 +17,12 @@
 - (BOOL)shouldReceiveTouchAtWindowPoint:(CGPoint)pointInWindowCoordinates;
 - (BOOL)wantsWindowToBecomeKey;
 
+/// @brief Used to present (or dismiss) a modal view controller ("tool"), typically triggered by pressing a button in the toolbar.
+///
+/// If a tool is already presented, this method simply dismisses it and calls the completion block.
+/// If no tool is presented, @code future() @endcode is presented and the completion block is called.
+- (void)toggleToolWithViewControllerProvider:(UIViewController *(^)())future completion:(void(^)())completion;
+
 // Keyboard shortcut helpers
 
 - (void)toggleSelectTool;


### PR DESCRIPTION
Removes duplicate code related to presenting a view controller from the
FLEX window (usually triggered by a toolbar button).

This adds `-[FLEXExplorerViewController
presentOrDismissViewControllerFromToolbar:shouldDismiss:completion:]`
which also makes it easier for others to add their own toolbar buttons
to present some other kind of screen, or for FLEX itself to utilize
again in the future.