### PR TITLE
Highlight request name in red if status code is a 4xx or 5xx

### DIFF
--- a/Classes/Network/FLEXNetworkTransactionTableViewCell.m
+++ b/Classes/Network/FLEXNetworkTransactionTableViewCell.m
@@ -79,7 +79,7 @@ NSString *const kFLEXNetworkTransactionCellIdentifier = @"kFLEXNetworkTransactio
     self.nameLabel.text = [self nameLabelText];
     CGSize nameLabelPreferredSize = [self.nameLabel sizeThatFits:CGSizeMake(availableTextWidth, CGFLOAT_MAX)];
     self.nameLabel.frame = CGRectMake(textOriginX, kVerticalPadding, availableTextWidth, nameLabelPreferredSize.height);
-    self.nameLabel.textColor = self.transaction.error ? [UIColor redColor] : [UIColor blackColor];
+    self.nameLabel.textColor = (self.transaction.error || [FLEXUtility isErrorStatusCodeFromURLResponse:self.transaction.response]) ? [UIColor redColor] : [UIColor blackColor];
 
     self.pathLabel.text = [self pathLabelText];
     CGSize pathLabelPreferredSize = [self.pathLabel sizeThatFits:CGSizeMake(availableTextWidth, CGFLOAT_MAX)];

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -35,6 +35,7 @@
 + (UIImage *)thumbnailedImageWithMaxPixelDimension:(NSInteger)dimension fromImageData:(NSData *)data;
 + (NSString *)stringFromRequestDuration:(NSTimeInterval)duration;
 + (NSString *)statusCodeStringFromURLResponse:(NSURLResponse *)response;
++ (BOOL)isErrorStatusCodeFromURLResponse:(NSURLResponse *)response;
 + (NSDictionary *)dictionaryFromQuery:(NSString *)query;
 + (NSString *)prettyJSONStringFromData:(NSData *)data;
 + (BOOL)isValidJSONData:(NSData *)data;

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -249,6 +249,18 @@
     return httpResponseString;
 }
 
++ (BOOL)isErrorStatusCodeFromURLResponse:(NSURLResponse *)response {
+    NSIndexSet *errorStatusCodes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(400, 200)];
+    
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        return [errorStatusCodes containsIndex:httpResponse.statusCode];
+    }
+    
+    return NO;
+}
+
+
 + (NSDictionary *)dictionaryFromQuery:(NSString *)query
 {
     NSMutableDictionary *queryDictionary = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Currently only if there's an error on the transaction will the name be displayed in red. Showing 4xx or 5xx errors in red is helpful when looking at a glance for failed requests.