### PR TITLE
NetworkHistory: Fix: NavigationBar disappeared. Keep filtered result …

### DIFF
--- a/Classes/Network/FLEXNetworkHistoryTableViewController.m
+++ b/Classes/Network/FLEXNetworkHistoryTableViewController.m
@@ -62,23 +62,29 @@
     self.searchController.delegate = self;
     self.searchController.searchResultsUpdater = self;
     self.searchController.dimsBackgroundDuringPresentation = NO;
+    self.searchController.hidesNavigationBarDuringPresentation = NO;
     self.tableView.tableHeaderView = self.searchController.searchBar;
 
     [self updateTransactions];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    self.searchController.searchBar.hidden = NO;
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    self.searchController.searchBar.hidden = YES;
+}
+
 - (void)settingsButtonTapped:(id)sender
 {
     FLEXNetworkSettingsTableViewController *settingsViewController = [[FLEXNetworkSettingsTableViewController alloc] init];
-    settingsViewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(settingsViewControllerDoneTapped:)];
     settingsViewController.title = @"Network Debugging Settings";
-    UINavigationController *wrapperNavigationController = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
-    [self presentViewController:wrapperNavigationController animated:YES completion:nil];
-}
-
-- (void)settingsViewControllerDoneTapped:(id)sender
-{
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [self.navigationController pushViewController:settingsViewController animated:YES];
 }
 
 - (void)updateTransactions


### PR DESCRIPTION
…after clicked back from TransactionDetailPage.

In NetworkHistory page, searchBar is alway appeared, even if entered FLEXNetworkTransactionDetailTableViewController.

NavigationBar disappeared if entered detail page.
It can be back to history page by click "Cancel" first, but history filtered result has been cleared.

FLEXNetworkSettingsTableViewController: Change presenting  to push.

![simulator screen shot 2017 7 12 4 57 17](https://user-images.githubusercontent.com/3426072/28109888-38160c46-6723-11e7-87d1-2cac10ce5c5d.png)
