### PR TITLE
Reveal exception reason in dialog

### DIFF
--- a/Classes/Utility/FLEXRuntimeUtility.m
+++ b/Classes/Utility/FLEXRuntimeUtility.m
@@ -375,8 +375,19 @@ const unsigned int kFLEXNumberOfImplicitArgs = 2;
     } @catch (NSException *exception) {
         // Bummer...
         if (error) {
-            NSDictionary<NSString *, id> *userInfo = @{ NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Exception thrown while performing selector %@ on object %@", NSStringFromSelector(selector), object]};
-            *error = [NSError errorWithDomain:FLEXRuntimeUtilityErrorDomain code:FLEXRuntimeUtilityErrorCodeInvocationFailed userInfo:userInfo];
+            // "… on <class>" / "… on instance of <class>"
+            NSString *class = NSStringFromClass([object class]);
+            NSString *calledOn = object == [object class] ? class : [@"an instance of " stringByAppendingString:class];
+
+            NSString *message = [NSString stringWithFormat:@"Exception '%@' thrown while performing selector '%@' on %@.\nReason:\n\n%@",
+                                 exception.name,
+                                 NSStringFromSelector(selector),
+                                 calledOn,
+                                 exception.reason];
+
+            *error = [NSError errorWithDomain:FLEXRuntimeUtilityErrorDomain
+                                         code:FLEXRuntimeUtilityErrorCodeInvocationFailed
+                                     userInfo:@{ NSLocalizedDescriptionKey : message }];
         }
     }
     


### PR DESCRIPTION
When a user-invoked method call fails, FLEX presents a dialog informing you that it failed, but does not say why.

In practice, it is more useful to see the exception name and reason than the (potentially crazy long) object description.