### PR TITLE
Fixed @availability clang compiler warning

### DIFF
--- a/Classes/Utility/FLEXKeyboardShortcutManager.m
+++ b/Classes/Utility/FLEXKeyboardShortcutManager.m
@@ -147,7 +147,7 @@
     
     [FLEXUtility replaceImplementationOfKnownSelector:originalKeyEventSelector onClass:[UIApplication class] withBlock:handleKeyUIEventSwizzleBlock swizzledSelector:swizzledKeyEventSelector];
     
-    if ([[UITouch class] instancesRespondToSelector:@selector(maximumPossibleForce)]) {
+    if (@available(iOS 9.0, *)) {
         SEL originalSendEventSelector = NSSelectorFromString(@"sendEvent:");
         SEL swizzledSendEventSelector = [FLEXUtility swizzledSelectorForSelector:originalSendEventSelector];
         


### PR DESCRIPTION
Changed `[[UITouch class] instancesRespondToSelector:@selector(maximumPossibleForce)]` check by `@available(iOS 9.0, *)` to avoid clang compiler warning.

