### PR TITLE
Add iPhone X safe area handling to layout the toolbar correctly

### DIFF
--- a/Classes/Toolbar/FLEXExplorerToolbar.h
+++ b/Classes/Toolbar/FLEXExplorerToolbar.h
@@ -14,7 +14,7 @@
 
 /// The items to be displayed in the toolbar. Defaults to:
 /// globalsItem, hierarchyItem, selectItem, moveItem, closeItem
-@property (nonatomic, copy) NSArray<UIView*> *toolbarItems;
+@property (nonatomic, copy) NSArray<UIView *> *toolbarItems;
 
 /// Toolbar item for selecting views.
 /// Users of the toolbar can configure the enabled/selected state and event targets/actions.

--- a/Classes/Toolbar/FLEXToolbarItem.h
+++ b/Classes/Toolbar/FLEXToolbarItem.h
@@ -12,6 +12,4 @@
 
 + (instancetype)toolbarItemWithTitle:(NSString *)title image:(UIImage *)image;
 
-+ (UIColor *)defaultBackgroundColor;
-
 @end

--- a/Classes/Toolbar/FLEXToolbarItem.m
+++ b/Classes/Toolbar/FLEXToolbarItem.m
@@ -70,7 +70,7 @@
 
 + (UIColor *)defaultBackgroundColor
 {
-    return [UIColor colorWithWhite:1.0 alpha:0.95];
+    return [UIColor clearColor];
 }
 
 + (CGFloat)topMargin

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -6,11 +6,15 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
+#import <Availability.h>
+#import <AvailabilityInternal.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 
 #define FLEXFloor(x) (floor([[UIScreen mainScreen] scale] * (x)) / [[UIScreen mainScreen] scale])
+
+#define FLEX_AT_LEAST_IOS11_SDK defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
 
 @interface FLEXUtility : NSObject
 


### PR DESCRIPTION
Add `safeAreaInsets` handling to make sure the toolbar can only be laid out in `safeArea`.

I made sure that the Y-axis `safeArea` handling was done in `FLEXExplorerToolbar`, so that the background can occupy the fullwidth, and only the content was laid out in `safeArea`. In order to do so, the default semi-transparent background color was moved from `FLEXToolbarItem` to `FLEXExplorerToolbar`.