### PR TITLE
Make Travis use xcodebuild (and xcpretty) instead of (deprecated) xctool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: objective-c
 xcode_workspace: FLEX.xcworkspace
+xcode_sdk: iphonesimulator
+before_install:
+    - gem install xcpretty
 matrix:
     include:
         - xcode_scheme: UICatalog
-          xcode_sdk: iphonesimulator
         - xcode_scheme: FLEX
-          xcode_sdk: iphonesimulator
+script:
+    - set -o pipefail
+    - xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK build | xcpretty


### PR DESCRIPTION
The `xctool` step failed in Travis CI. The reason is the `xctool` doesn't support `build` action anymore in the most recent version. See:
https://travis-ci.org/Flipboard/FLEX/jobs/317617537
https://github.com/travis-ci/docs-travis-ci-com/issues/1186
https://github.com/facebook/xctool