### PR TITLE
Use FOUNDATION_EXTERN for global variable

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.h
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const kFLEXNetworkObserverEnabledStateChangedNotification;
+FOUNDATION_EXTERN NSString *const kFLEXNetworkObserverEnabledStateChangedNotification;
 
 /// This class swizzles NSURLConnection and NSURLSession delegate methods to observe events in the URL loading system.
 /// High level network events are sent to the default FLEXNetworkRecorder instance which maintains the request history and caches response bodies.


### PR DESCRIPTION
Global variables that can be accessed from both C (or Objective-C) and
C++ (or Objective-C++) source files should be marked `extern "C"` when
in C++ mode (which is what `FOUNDATION_EXTERN` does), to ensure
consistent access across languages.