### PR TITLE
Fix heap enumeration crash

### DIFF
--- a/Classes/Utility/FLEXHeapEnumerator.m
+++ b/Classes/Utility/FLEXHeapEnumerator.m
@@ -71,8 +71,9 @@ static kern_return_t reader(__unused task_t remote_task, vm_address_t remote_add
         for (unsigned int i = 0; i < zoneCount; i++) {
             malloc_zone_t *zone = (malloc_zone_t *)zones[i];
             malloc_introspection_t *introspection = zone->introspect;
+            NSString *zoneName = @(zone->zone_name);
 
-            if (!introspection) {
+            if (![zoneName isEqualToString:@"DefaultMallocZone"] || !introspection) {
                 continue;
             }
 
@@ -107,6 +108,9 @@ static kern_return_t reader(__unused task_t remote_task, vm_address_t remote_add
                 introspection->enumerator(TASK_NULL, (void *)&callback, MALLOC_PTR_IN_USE_RANGE_TYPE, (vm_address_t)zone, reader, &range_callback);
                 unlock_zone(zone);
             }
+
+            // Only one zone to enumerate
+            break;
         }
     }
 }


### PR DESCRIPTION
We only need to enumerate the `DefaultMallocZone` zone to find objects in the Objc runtime.

---

I have [several outstanding PRs.](https://github.com/Flipboard/FLEX/pulls/NSExceptional) Most of them are very simple. I don't know who else to contact about this except to just mention it here and hope someone important sees it. @matrush, could you take a look at some of them?