### PR TITLE
Fix safeArea for database content view

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
@@ -52,10 +52,13 @@ static const CGFloat kColumnMargin = 1;
     CGFloat topheaderHeight = [self topHeaderHeight];
     CGFloat leftHeaderWidth = [self leftHeaderWidth];
     CGFloat topInsets = 0.f;
-    
+
+    #if FLEX_AT_LEAST_IOS11_SDK
     if (@available (iOS 11.0, *)) {
         topInsets = self.safeAreaInsets.top;
     }
+    #endif
+    
     CGFloat contentWidth = 0.0;
     NSInteger rowsCount = [self numberOfColumns];
     for (int i = 0; i < rowsCount; i++) {

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
@@ -53,11 +53,11 @@ static const CGFloat kColumnMargin = 1;
     CGFloat leftHeaderWidth = [self leftHeaderWidth];
     CGFloat topInsets = 0.f;
 
-    #if FLEX_AT_LEAST_IOS11_SDK
+#if FLEX_AT_LEAST_IOS11_SDK
     if (@available (iOS 11.0, *)) {
         topInsets = self.safeAreaInsets.top;
     }
-    #endif
+#endif
     
     CGFloat contentWidth = 0.0;
     NSInteger rowsCount = [self numberOfColumns];

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
@@ -51,20 +51,24 @@ static const CGFloat kColumnMargin = 1;
     CGFloat height = self.frame.size.height;
     CGFloat topheaderHeight = [self topHeaderHeight];
     CGFloat leftHeaderWidth = [self leftHeaderWidth];
+    CGFloat topInsets = 0.f;
     
+    if (@available (iOS 11.0, *)) {
+        topInsets = self.safeAreaInsets.top;
+    }
     CGFloat contentWidth = 0.0;
     NSInteger rowsCount = [self numberOfColumns];
     for (int i = 0; i < rowsCount; i++) {
         contentWidth += [self contentWidthForColumn:i];
     }
     
-    self.leftTableView.frame           = CGRectMake(0, topheaderHeight, leftHeaderWidth, height - topheaderHeight);
-    self.headerScrollView.frame        = CGRectMake(leftHeaderWidth, 0, width - leftHeaderWidth, topheaderHeight);
+    self.leftTableView.frame           = CGRectMake(0, topheaderHeight + topInsets, leftHeaderWidth, height - topheaderHeight - topInsets);
+    self.headerScrollView.frame        = CGRectMake(leftHeaderWidth, topInsets, width - leftHeaderWidth, topheaderHeight);
     self.headerScrollView.contentSize  = CGSizeMake( self.contentTableView.frame.size.width, self.headerScrollView.frame.size.height);
-    self.contentTableView.frame        = CGRectMake(0, 0, contentWidth + [self numberOfColumns] * [self columnMargin] , height - topheaderHeight);
-    self.contentScrollView.frame       = CGRectMake(leftHeaderWidth, topheaderHeight, width - leftHeaderWidth, height - topheaderHeight);
+    self.contentTableView.frame        = CGRectMake(0, 0, contentWidth + [self numberOfColumns] * [self columnMargin] , height - topheaderHeight - topInsets);
+    self.contentScrollView.frame       = CGRectMake(leftHeaderWidth, topheaderHeight + topInsets, width - leftHeaderWidth, height - topheaderHeight - topInsets);
     self.contentScrollView.contentSize = self.contentTableView.frame.size;
-    self.leftHeader.frame              = CGRectMake(0, 0, [self leftHeaderWidth], [self topHeaderHeight]);
+    self.leftHeader.frame              = CGRectMake(0, topInsets, [self leftHeaderWidth], [self topHeaderHeight]);
 }
 
 


### PR DESCRIPTION
Currently, if you use iPhone X or any iPhone with a notch to view database, the column names will be hidden under the navigation bar. This is because the safeArea is not respected. This commit contains a simple fix to that.