### PR TITLE
Remove curl shortening

### DIFF
--- a/Classes/GlobalStateExplorers/FLEXAddressInspectorViewController.h
+++ b/Classes/GlobalStateExplorers/FLEXAddressInspectorViewController.h
@@ -1,0 +1,15 @@
+//
+//  FLEXAddressInspectorViewController.h
+//  FLEX
+//
+//  Created by Alexander Leontev on 08/04/2019.
+//  Copyright © 2019 Flipboard. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+
+@interface FLEXAddressInspectorViewController : UITableViewController
+
+@end
+

--- a/Classes/GlobalStateExplorers/FLEXAddressInspectorViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXAddressInspectorViewController.m
@@ -1,0 +1,102 @@
+//
+//  FLEXAddressInspectorViewController.m
+//  FLEX
+//
+//  Created by Alexander Leontev on 08/04/2019.
+//  Copyright © 2019 Flipboard. All rights reserved.
+//
+
+#import "FLEXAddressInspectorViewController.h"
+#import "FLEXUtility.h"
+#import "FLEXObjectExplorerViewController.h"
+#import "FLEXObjectExplorerFactory.h"
+
+@interface FLEXAddressInspectorViewController () <UISearchBarDelegate>
+
+@property (nonatomic, strong) UISearchBar *searchBar;
+
+@end
+
+@implementation FLEXAddressInspectorViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.searchBar = [[UISearchBar alloc] init];
+    self.searchBar.placeholder = @"Memory address";
+    self.searchBar.delegate = self;
+    [self.searchBar sizeToFit];
+    
+    self.title = @"Address Inspector";
+    
+    self.tableView.tableHeaderView = self.searchBar;
+}
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
+{
+    [self.tableView reloadData];
+}
+
+- (void)openInstanceInspectorForAddress:(NSString *)address {
+    
+    NSScanner *scanner = [NSScanner scannerWithString:address];
+    
+    unsigned long long objectPointerValue = 0;
+    BOOL didParseAddress = [scanner scanHexLongLong:&objectPointerValue];
+    
+    const void *objectPointer = (const void *)objectPointerValue;
+    
+    if (didParseAddress) {
+        id object = (__bridge id)objectPointer;
+        
+        FLEXObjectExplorerViewController *drillInViewController = [FLEXObjectExplorerFactory explorerViewControllerForObject:object];
+        [self.navigationController pushViewController:drillInViewController animated:YES];
+    }
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    
+    static NSString *CellIdentifier = @"Cell";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
+        UIFont *cellFont = [FLEXUtility defaultTableViewCellLabelFont];
+        cell.textLabel.font = cellFont;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
+        cell.detailTextLabel.font = cellFont;
+        cell.detailTextLabel.textColor = [UIColor grayColor];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.detailTextLabel.text = @"WARNING! Inspecting incorrect address will crash the application";
+    }
+    
+    cell.textLabel.text = [NSString stringWithFormat:@"Inspect %@", self.searchBar.text];
+    
+    return cell;
+    
+}
+
+- (BOOL)isAddressValid {
+    
+    return [self.searchBar.text rangeOfString:@"^0[xX][0-9a-fA-F]+$" options:NSRegularExpressionSearch].location != NSNotFound;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    return 48.0;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return [self isAddressValid];
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    
+    [self openInstanceInspectorForAddress:self.searchBar.text];
+}
+
+
+@end

--- a/Classes/GlobalStateExplorers/FLEXGlobalsTableViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXGlobalsTableViewController.m
@@ -19,6 +19,7 @@
 #import "FLEXManager+Private.h"
 #import "FLEXSystemLogTableViewController.h"
 #import "FLEXNetworkHistoryTableViewController.h"
+#import "FLEXAddressInspectorViewController.h"
 
 static __weak UIWindow *s_applicationWindow = nil;
 
@@ -26,6 +27,7 @@ typedef NS_ENUM(NSUInteger, FLEXGlobalsRow) {
     FLEXGlobalsRowNetworkHistory,
     FLEXGlobalsRowSystemLog,
     FLEXGlobalsRowLiveObjects,
+    FLEXGlobalsRowAddressInspector,
     FLEXGlobalsRowFileBrowser,
     FLEXGlobalsCookies,    
     FLEXGlobalsRowSystemLibraries,
@@ -67,6 +69,17 @@ typedef NS_ENUM(NSUInteger, FLEXGlobalsRow) {
                     classesViewController.binaryImageName = [FLEXUtility applicationImageName];
 
                     return classesViewController;
+                };
+                break;
+                
+            case FLEXGlobalsRowAddressInspector:
+                titleFuture = ^NSString *{
+                    return @"🔎 Address Inspector";
+                };
+                
+                viewControllerFuture = ^UIViewController *{
+                    FLEXAddressInspectorViewController *addressInspectorViewController = [[FLEXAddressInspectorViewController alloc] initWithStyle:UITableViewStyleGrouped];
+                    return addressInspectorViewController;
                 };
                 break;
 

--- a/Classes/Network/FLEXNetworkCurlLogger.m
+++ b/Classes/Network/FLEXNetworkCurlLogger.m
@@ -28,12 +28,7 @@
     }
 
     if (request.HTTPBody) {
-        if ([request.allHTTPHeaderFields[@"Content-Length"] intValue] < 1024) {
-            [curlCommandString appendFormat:@"-d \'%@\'",
-             [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]];
-        } else {
-            [curlCommandString appendFormat:@"[TOO MUCH DATA TO INCLUDE]"];
-        }
+            [curlCommandString appendFormat:@"-d \'%@\'", [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]];
     }
 
     return curlCommandString;

--- a/Classes/ObjectExplorers/FLEXObjectExplorerViewController.h
+++ b/Classes/ObjectExplorers/FLEXObjectExplorerViewController.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSUInteger, FLEXObjectExplorerSection) {
+    FLEXObjectExplorerSectionAddress,
     FLEXObjectExplorerSectionDescription,
     FLEXObjectExplorerSectionCustom,
     FLEXObjectExplorerSectionProperties,

--- a/Classes/ObjectExplorers/FLEXObjectExplorerViewController.m
+++ b/Classes/ObjectExplorers/FLEXObjectExplorerViewController.m
@@ -601,7 +601,8 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
     static NSArray<NSNumber *> *possibleSections = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        possibleSections = @[@(FLEXObjectExplorerSectionDescription),
+        possibleSections = @[@(FLEXObjectExplorerSectionAddress),
+                             @(FLEXObjectExplorerSectionDescription),
                              @(FLEXObjectExplorerSectionCustom),
                              @(FLEXObjectExplorerSectionProperties),
                              @(FLEXObjectExplorerSectionIvars),
@@ -647,6 +648,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     NSInteger numberOfRows = 0;
     switch (section) {
+        case FLEXObjectExplorerSectionAddress:
+            numberOfRows = 1;
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             numberOfRows = [self shouldShowDescription] ? 1 : 0;
             break;
@@ -687,6 +692,11 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     NSString *title = nil;
     switch (section) {
+            
+        case FLEXObjectExplorerSectionAddress:
+            title = [FLEXUtility addressForObject:self.object];
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             title = [FLEXUtility safeDescriptionForObject:self.object];
             break;
@@ -726,6 +736,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     NSString *subtitle = nil;
     switch (section) {
+            
+        case FLEXObjectExplorerSectionAddress:
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             break;
             
@@ -760,6 +774,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     BOOL canDrillIn = NO;
     switch (section) {
+            
+        case FLEXObjectExplorerSectionAddress:
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             break;
             
@@ -813,6 +831,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
     BOOL canCopy = NO;
     
     switch (section) {
+        case FLEXObjectExplorerSectionAddress:
+            canCopy = YES;
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             canCopy = YES;
             break;
@@ -827,6 +849,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     NSString *title = nil;
     switch (section) {
+        case FLEXObjectExplorerSectionAddress: {
+            title = @"Address";
+        } break;
+            
         case FLEXObjectExplorerSectionDescription: {
             title = @"Description";
         } break;
@@ -870,6 +896,10 @@ typedef NS_ENUM(NSUInteger, FLEXMetadataKind) {
 {
     UIViewController *viewController = nil;
     switch (section) {
+            
+        case FLEXObjectExplorerSectionAddress:
+            break;
+            
         case FLEXObjectExplorerSectionDescription:
             break;
             

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -34,6 +34,7 @@
 + (NSString *)applicationImageName;
 + (NSString *)applicationName;
 + (NSString *)safeDescriptionForObject:(id)object;
++ (NSString *)addressForObject:(id)object;
 + (UIFont *)defaultFontOfSize:(CGFloat)size;
 + (UIFont *)defaultTableViewCellLabelFont;
 + (NSString *)stringByEscapingHTMLEntitiesInString:(NSString *)originalString;

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -126,6 +126,10 @@
     return description;
 }
 
++ (NSString *)addressForObject:(id)object {
+    return [NSString stringWithFormat:@"%p", object];
+}
+
 + (UIFont *)defaultFontOfSize:(CGFloat)size
 {
     return [UIFont fontWithName:@"HelveticaNeue" size:size];

--- a/Example/UICatalog/AAPLTextViewController.m
+++ b/Example/UICatalog/AAPLTextViewController.m
@@ -61,6 +61,10 @@
 
 @implementation AAPLTextViewController
 
+- (void)dealloc {
+    NSLog(@"Ass");
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		224D49AB1C673AB5000EAB86 /* FLEXSQLiteDatabaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 224D49A71C673AB5000EAB86 /* FLEXSQLiteDatabaseManager.m */; };
 		2EF6B04D1D494BE50006BDA5 /* FLEXNetworkCurlLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EF6B04B1D494BE50006BDA5 /* FLEXNetworkCurlLogger.m */; };
 		2EF6B04E1D494BE50006BDA5 /* FLEXNetworkCurlLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF6B04C1D494BE50006BDA5 /* FLEXNetworkCurlLogger.h */; };
+		3894176E225B592400DC827E /* FLEXAddressInspectorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3894176C225B592400DC827E /* FLEXAddressInspectorViewController.h */; };
+		3894176F225B592400DC827E /* FLEXAddressInspectorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3894176D225B592400DC827E /* FLEXAddressInspectorViewController.m */; };
 		3A4C94251B5B20570088C3F2 /* FLEX.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C94241B5B20570088C3F2 /* FLEX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A4C94C51B5B21410088C3F2 /* FLEXArrayExplorerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C943C1B5B21410088C3F2 /* FLEXArrayExplorerViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A4C94C61B5B21410088C3F2 /* FLEXArrayExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C943D1B5B21410088C3F2 /* FLEXArrayExplorerViewController.m */; };
@@ -203,6 +205,8 @@
 		224D49A71C673AB5000EAB86 /* FLEXSQLiteDatabaseManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXSQLiteDatabaseManager.m; sourceTree = "<group>"; };
 		2EF6B04B1D494BE50006BDA5 /* FLEXNetworkCurlLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXNetworkCurlLogger.m; sourceTree = "<group>"; };
 		2EF6B04C1D494BE50006BDA5 /* FLEXNetworkCurlLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXNetworkCurlLogger.h; sourceTree = "<group>"; };
+		3894176C225B592400DC827E /* FLEXAddressInspectorViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLEXAddressInspectorViewController.h; sourceTree = "<group>"; };
+		3894176D225B592400DC827E /* FLEXAddressInspectorViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLEXAddressInspectorViewController.m; sourceTree = "<group>"; };
 		3A4C941F1B5B20570088C3F2 /* FLEX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FLEX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A4C94231B5B20570088C3F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A4C94241B5B20570088C3F2 /* FLEX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FLEX.h; sourceTree = "<group>"; };
@@ -588,6 +592,8 @@
 			children = (
 				779B1EBF1C0C4D7C001F5E49 /* DatabaseBrowser */,
 				3A4C94AD1B5B21410088C3F2 /* SystemLog */,
+				3894176C225B592400DC827E /* FLEXAddressInspectorViewController.h */,
+				3894176D225B592400DC827E /* FLEXAddressInspectorViewController.m */,
 				3A4C949B1B5B21410088C3F2 /* FLEXClassesTableViewController.h */,
 				3A4C949C1B5B21410088C3F2 /* FLEXClassesTableViewController.m */,
 				3A4C949D1B5B21410088C3F2 /* FLEXFileBrowserFileOperationController.h */,
@@ -757,6 +763,7 @@
 				3A4C94E31B5B21410088C3F2 /* FLEXRuntimeUtility.h in Headers */,
 				3A4C95341B5B21410088C3F2 /* FLEXSystemLogTableViewController.h in Headers */,
 				3A4C95091B5B21410088C3F2 /* FLEXFieldEditorView.h in Headers */,
+				3894176E225B592400DC827E /* FLEXAddressInspectorViewController.h in Headers */,
 				3A4C950D1B5B21410088C3F2 /* FLEXIvarEditorViewController.h in Headers */,
 				3A4C95281B5B21410088C3F2 /* FLEXInstancesTableViewController.h in Headers */,
 				3A4C950F1B5B21410088C3F2 /* FLEXMethodCallingViewController.h in Headers */,
@@ -927,6 +934,7 @@
 				224D49A91C673AB5000EAB86 /* FLEXRealmDatabaseManager.m in Sources */,
 				2EF6B04D1D494BE50006BDA5 /* FLEXNetworkCurlLogger.m in Sources */,
 				94A515201C4CA1F10063292F /* FLEXWindow.m in Sources */,
+				3894176F225B592400DC827E /* FLEXAddressInspectorViewController.m in Sources */,
 				3A4C95121B5B21410088C3F2 /* FLEXPropertyEditorViewController.m in Sources */,
 				3A4C95391B5B21410088C3F2 /* FLEXNetworkRecorder.m in Sources */,
 				3A4C950E1B5B21410088C3F2 /* FLEXIvarEditorViewController.m in Sources */,


### PR DESCRIPTION
* Copying curl request should not be trimmed, as long curl requests are prime target for copying - manually building them is tedious, and they should be available regardless of the size.