### PR TITLE
Remove copied curl shortening

### DIFF
--- a/Classes/Network/FLEXNetworkCurlLogger.m
+++ b/Classes/Network/FLEXNetworkCurlLogger.m
@@ -28,12 +28,7 @@
     }
 
     if (request.HTTPBody) {
-        if ([request.allHTTPHeaderFields[@"Content-Length"] intValue] < 1024) {
-            [curlCommandString appendFormat:@"-d \'%@\'",
-             [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]];
-        } else {
-            [curlCommandString appendFormat:@"[TOO MUCH DATA TO INCLUDE]"];
-        }
+            [curlCommandString appendFormat:@"-d \'%@\'", [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding]];
     }
 
     return curlCommandString;


### PR DESCRIPTION
Copying curl request should not be trimmed, as long curl requests are prime target for copying - manually building them is tedious, and they should be available regardless of the size