### PR TITLE
Add ability to use object-by-address for method arguments with type id

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.h
@@ -1,5 +1,5 @@
 //
-//  FLEXArgumentInputJSONObjectView.h
+//  FLEXArgumentInputObjectView.h
 //  Flipboard
 //
 //  Created by Ryan Olson on 6/15/14.
@@ -8,7 +8,6 @@
 
 #import "FLEXArgumentInputTextView.h"
 
-// #warning TODO This is never supported
-@interface FLEXArgumentInputJSONObjectView : FLEXArgumentInputTextView
+@interface FLEXArgumentInputObjectView : FLEXArgumentInputTextView
 
 @end

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.m
@@ -1,15 +1,15 @@
 //
-//  FLEXArgumentInputJSONObjectView.m
+//  FLEXArgumentInputObjectView.m
 //  Flipboard
 //
 //  Created by Ryan Olson on 6/15/14.
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputJSONObjectView.h"
+#import "FLEXArgumentInputObjectView.h"
 #import "FLEXRuntimeUtility.h"
 
-@implementation FLEXArgumentInputJSONObjectView
+@implementation FLEXArgumentInputObjectView
 
 - (instancetype)initWithArgumentTypeEncoding:(const char *)typeEncoding
 {

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.m
@@ -1,5 +1,5 @@
 //
-//  FLEXArgumentInputObjectView.m
+//  FLEXArgumentInputJSONObjectView.m
 //  Flipboard
 //
 //  Created by Ryan Olson on 6/15/14.
@@ -8,6 +8,20 @@
 
 #import "FLEXArgumentInputObjectView.h"
 #import "FLEXRuntimeUtility.h"
+
+static const CGFloat kSegmentInputMargin = 4;
+
+typedef NS_ENUM(NSUInteger, FLEXArgInputObjectType) {
+    FLEXArgInputObjectTypeJSON,
+    FLEXArgInputObjectTypeAddress
+};
+
+@interface FLEXArgumentInputObjectView ()
+
+@property (nonatomic) UISegmentedControl *objectTypeSegmentControl;
+@property (nonatomic) FLEXArgInputObjectType inputType;
+
+@end
 
 @implementation FLEXArgumentInputObjectView
 
@@ -19,47 +33,170 @@
         // square brackets are likely to be the first characters type for the JSON.
         self.inputTextView.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
         self.targetSize = FLEXArgumentInputViewSizeLarge;
+
+        self.objectTypeSegmentControl = [[UISegmentedControl alloc] initWithItems:@[@"Value", @"Address"]];
+        [self.objectTypeSegmentControl addTarget:self action:@selector(didChangeType) forControlEvents:UIControlEventValueChanged];
+        self.objectTypeSegmentControl.selectedSegmentIndex = 0;
+        [self addSubview:self.objectTypeSegmentControl];
+
+        self.inputType = [[self class] preferredDefaultTypeForObjCType:typeEncoding withCurrentValue:nil];
+        self.objectTypeSegmentControl.selectedSegmentIndex = self.inputType;
     }
+
     return self;
+}
+
+- (void)didChangeType
+{
+    self.inputType = self.objectTypeSegmentControl.selectedSegmentIndex;
+
+    if (super.inputValue) {
+        // Trigger an update to the text field to show
+        // the address of the stored object we were given,
+        // or to show a JSON representation of the object
+        [self populateTextAreaFromValue:super.inputValue];
+    } else {
+        // Clear the text field
+        self.inputValue = nil;
+    }
+}
+
+- (void)setInputType:(FLEXArgInputObjectType)inputType {
+    if (_inputType == inputType) return;
+
+    _inputType = inputType;
+
+    // Resize input view
+    switch (inputType) {
+        case FLEXArgInputObjectTypeJSON:
+            self.targetSize = FLEXArgumentInputViewSizeLarge;
+            break;
+        case FLEXArgInputObjectTypeAddress:
+            self.targetSize = FLEXArgumentInputViewSizeSmall;
+            break;
+    }
+
+    [self setNeedsLayout];
+    [self.superview setNeedsLayout];
 }
 
 - (void)setInputValue:(id)inputValue
 {
-    self.inputTextView.text = [FLEXRuntimeUtility editableJSONStringForObject:inputValue];
+    super.inputValue = inputValue;
+    [self populateTextAreaFromValue:inputValue];
 }
 
 - (id)inputValue
 {
-    return [FLEXRuntimeUtility objectValueFromEditableJSONString:self.inputTextView.text];
+    switch (self.inputType) {
+        case FLEXArgInputObjectTypeJSON:
+            return [FLEXRuntimeUtility objectValueFromEditableJSONString:self.inputTextView.text];
+        case FLEXArgInputObjectTypeAddress: {
+            NSScanner *scanner = [NSScanner scannerWithString:self.inputTextView.text];
+
+            unsigned long long objectPointerValue;
+            if ([scanner scanHexLongLong:&objectPointerValue]) {
+                return (__bridge id)(void *)objectPointerValue;
+            }
+
+            return nil;
+        }
+    }
+}
+
+- (void)populateTextAreaFromValue:(id)value
+{
+    if (self.inputType == FLEXArgInputObjectTypeJSON) {
+        self.inputTextView.text = [FLEXRuntimeUtility editableJSONStringForObject:value];
+    } else if (self.inputType == FLEXArgInputObjectTypeAddress) {
+        self.inputTextView.text = [NSString stringWithFormat:@"%p", value];
+    }
+}
+
+- (CGSize)sizeThatFits:(CGSize)size
+{
+    CGSize fitSize = [super sizeThatFits:size];
+    fitSize.height += [self.objectTypeSegmentControl sizeThatFits:size].height + kSegmentInputMargin;
+
+    return fitSize;
+}
+
+- (void)layoutSubviews {
+    // Must be called first since we are overriding self.inputTextView's position
+    [super layoutSubviews];
+
+    CGFloat segmentHeight = [self.objectTypeSegmentControl sizeThatFits:self.frame.size].height;
+
+    self.inputTextView.frame = CGRectMake(
+        0.0,
+        segmentHeight + self.topInputFieldVerticalLayoutGuide + kSegmentInputMargin,
+        self.inputTextView.frame.size.width,
+        self.inputTextView.frame.size.height
+    );
+    self.objectTypeSegmentControl.frame = CGRectMake(
+        0.0,
+        self.topInputFieldVerticalLayoutGuide,
+        self.frame.size.width,
+        segmentHeight
+    );
 }
 
 + (BOOL)supportsObjCType:(const char *)type withCurrentValue:(id)value
 {
-    // Must be object type.
-    BOOL supported = type && type[0] == '@';
-    
-    if (supported) {
-        if (value) {
-            // If there's a current value, it must be serializable to JSON
-            supported = [FLEXRuntimeUtility editableJSONStringForObject:value] != nil;
+    NSParameterAssert(type);
+    // Must be object type
+    return type[0] == '@';
+}
+
++ (FLEXArgInputObjectType)preferredDefaultTypeForObjCType:(const char *)type withCurrentValue:(id)value
+{
+    NSParameterAssert(type[0] == '@');
+
+    if (value) {
+        // If there's a current value, it must be serializable to JSON
+        // to display the JSON editor. Otherwise display the address field.
+        if ([FLEXRuntimeUtility editableJSONStringForObject:value]) {
+            return FLEXArgInputObjectTypeJSON;
         } else {
-            // Otherwise, see if we have more type information than just 'id'.
-            // If we do, make sure the encoding is something serializable to JSON.
-            // Properties and ivars keep more detailed type encoding information than method arguments.
-            if (strcmp(type, @encode(id)) != 0) {
-                BOOL isJSONSerializableType = NO;
-                // Note: we can't use @encode(NSString) here because that drops the string information and just goes to @encode(id).
-                isJSONSerializableType = isJSONSerializableType || strcmp(type, FLEXEncodeClass(NSString)) == 0;
-                isJSONSerializableType = isJSONSerializableType || strcmp(type, FLEXEncodeClass(NSNumber)) == 0;
-                isJSONSerializableType = isJSONSerializableType || strcmp(type, FLEXEncodeClass(NSArray)) == 0;
-                isJSONSerializableType = isJSONSerializableType || strcmp(type, FLEXEncodeClass(NSDictionary)) == 0;
-                
-                supported = isJSONSerializableType;
+            return FLEXArgInputObjectTypeAddress;
+        }
+    } else {
+        // Otherwise, see if we have more type information than just 'id'.
+        // If we do, make sure the encoding is something serializable to JSON.
+        // Properties and ivars keep more detailed type encoding information than method arguments.
+        if (strcmp(type, @encode(id)) != 0) {
+            BOOL isJSONSerializableType = NO;
+
+            // Note: we can't use @encode(NSString) here because that drops
+            // the class information and just goes to @encode(id).
+            NSArray *jsonTypes = @[
+                @(FLEXEncodeClass(NSString)),
+                @(FLEXEncodeClass(NSNumber)),
+                @(FLEXEncodeClass(NSArray)),
+                @(FLEXEncodeClass(NSDictionary)),
+                @(FLEXEncodeClass(NSMutableString)),
+                @(FLEXEncodeClass(NSMutableArray)),
+                @(FLEXEncodeClass(NSMutableDictionary)),
+            ];
+
+            // Look for matching types
+            NSString *typeStr = @(type);
+            for (NSString *encodedClass in jsonTypes) {
+                if ([typeStr isEqualToString:encodedClass]) {
+                    isJSONSerializableType = YES;
+                    break;
+                }
             }
+
+            if (isJSONSerializableType) {
+                return FLEXArgInputObjectTypeJSON;
+            } else {
+                return FLEXArgInputObjectTypeAddress;
+            }
+        } else {
+            return FLEXArgInputObjectTypeAddress;
         }
     }
-    
-    return supported;
 }
 
 @end

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.h
@@ -8,10 +8,11 @@
 
 #import "FLEXArgumentInputView.h"
 
-@interface FLEXArgumentInputTextView : FLEXArgumentInputView
+@interface FLEXArgumentInputTextView : FLEXArgumentInputView <UITextViewDelegate>
 
 // For subclass eyes only
 
-@property (nonatomic, strong, readonly) UITextView *inputTextView;
+@property (nonatomic, readonly) UITextView *inputTextView;
+@property (nonatomic) NSString *inputPlaceholderText;
 
 @end

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
@@ -82,21 +82,14 @@
 
 - (NSUInteger)numberOfInputLines
 {
-    NSUInteger numberOfInputLines = 0;
     switch (self.targetSize) {
         case FLEXArgumentInputViewSizeDefault:
-            numberOfInputLines = 2;
-            break;
-            
+            return 2;
         case FLEXArgumentInputViewSizeSmall:
-            numberOfInputLines = 1;
-            break;
-            
+            return 1;
         case FLEXArgumentInputViewSizeLarge:
-            numberOfInputLines = 8;
-            break;
+            return 8;
     }
-    return numberOfInputLines;
 }
 
 - (CGFloat)inputTextViewHeight

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputView.h
@@ -26,7 +26,8 @@ typedef NS_ENUM(NSUInteger, FLEXArgumentInputViewSize) {
 /// To populate the filed with an initial value, set this property.
 /// To reteive the value input by the user, access the property.
 /// Primitive types and structs should/will be boxed in NSValue containers.
-/// Concrete subclasses *must* override both the setter and getter for this property.
+/// Concrete subclasses should override both the setter and getter for this property.
+/// Subclasses can call super.inputValue to access a backing store for the value.
 @property (nonatomic) id inputValue;
 
 /// Setting this value to large will make some argument input views increase the size of their input field(s).

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputView.m
@@ -89,17 +89,6 @@
     return NO;
 }
 
-- (void)setInputValue:(id)inputValue
-{
-    // Subclasses should override.
-}
-
-- (id)inputValue
-{
-    // Subclasses should override.
-    return nil;
-}
-
 + (BOOL)supportsObjCType:(const char *)type withCurrentValue:(id)value
 {
     return NO;

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputViewFactory.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputViewFactory.m
@@ -8,7 +8,7 @@
 
 #import "FLEXArgumentInputViewFactory.h"
 #import "FLEXArgumentInputView.h"
-#import "FLEXArgumentInputJSONObjectView.h"
+#import "FLEXArgumentInputObjectView.h"
 #import "FLEXArgumentInputNumberView.h"
 #import "FLEXArgumentInputSwitchView.h"
 #import "FLEXArgumentInputStructView.h"
@@ -46,7 +46,7 @@
                                          [FLEXArgumentInputSwitchView class],
                                          [FLEXArgumentInputDateView class],
                                          [FLEXArgumentInputNumberView class],
-                                         [FLEXArgumentInputJSONObjectView class]];
+                                         [FLEXArgumentInputObjectView class]];
     
     // Note that order is important here since multiple subclasses may support the same type.
     // An example is the number subclass and the bool subclass for the type @encode(BOOL).

--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -64,8 +64,8 @@
 		3A4C94F21B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C946D1B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.m */; };
 		3A4C94F31B5B21410088C3F2 /* FLEXArgumentInputFontView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C946E1B5B21410088C3F2 /* FLEXArgumentInputFontView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A4C94F41B5B21410088C3F2 /* FLEXArgumentInputFontView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C946F1B5B21410088C3F2 /* FLEXArgumentInputFontView.m */; };
-		3A4C94F51B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C94701B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3A4C94F61B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C94711B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.m */; };
+		3A4C94F51B5B21410088C3F2 /* FLEXArgumentInputObjectView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C94701B5B21410088C3F2 /* FLEXArgumentInputObjectView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A4C94F61B5B21410088C3F2 /* FLEXArgumentInputObjectView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C94711B5B21410088C3F2 /* FLEXArgumentInputObjectView.m */; };
 		3A4C94F71B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C94721B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A4C94F81B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C94731B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.m */; };
 		3A4C94F91B5B21410088C3F2 /* FLEXArgumentInputNumberView.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4C94741B5B21410088C3F2 /* FLEXArgumentInputNumberView.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -266,8 +266,8 @@
 		3A4C946D1B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputFontsPickerView.m; sourceTree = "<group>"; };
 		3A4C946E1B5B21410088C3F2 /* FLEXArgumentInputFontView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputFontView.h; sourceTree = "<group>"; };
 		3A4C946F1B5B21410088C3F2 /* FLEXArgumentInputFontView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputFontView.m; sourceTree = "<group>"; };
-		3A4C94701B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputJSONObjectView.h; sourceTree = "<group>"; };
-		3A4C94711B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputJSONObjectView.m; sourceTree = "<group>"; };
+		3A4C94701B5B21410088C3F2 /* FLEXArgumentInputObjectView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputObjectView.h; sourceTree = "<group>"; };
+		3A4C94711B5B21410088C3F2 /* FLEXArgumentInputObjectView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputObjectView.m; sourceTree = "<group>"; };
 		3A4C94721B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputNotSupportedView.h; sourceTree = "<group>"; };
 		3A4C94731B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXArgumentInputNotSupportedView.m; sourceTree = "<group>"; };
 		3A4C94741B5B21410088C3F2 /* FLEXArgumentInputNumberView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXArgumentInputNumberView.h; sourceTree = "<group>"; };
@@ -557,8 +557,8 @@
 				3A4C946D1B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.m */,
 				3A4C946E1B5B21410088C3F2 /* FLEXArgumentInputFontView.h */,
 				3A4C946F1B5B21410088C3F2 /* FLEXArgumentInputFontView.m */,
-				3A4C94701B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.h */,
-				3A4C94711B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.m */,
+				3A4C94701B5B21410088C3F2 /* FLEXArgumentInputObjectView.h */,
+				3A4C94711B5B21410088C3F2 /* FLEXArgumentInputObjectView.m */,
 				3A4C94721B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.h */,
 				3A4C94731B5B21410088C3F2 /* FLEXArgumentInputNotSupportedView.m */,
 				3A4C94741B5B21410088C3F2 /* FLEXArgumentInputNumberView.h */,
@@ -834,7 +834,7 @@
 				3A4C950D1B5B21410088C3F2 /* FLEXIvarEditorViewController.h in Headers */,
 				3A4C95281B5B21410088C3F2 /* FLEXInstancesTableViewController.h in Headers */,
 				3A4C950F1B5B21410088C3F2 /* FLEXMethodCallingViewController.h in Headers */,
-				3A4C94F51B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.h in Headers */,
+				3A4C94F51B5B21410088C3F2 /* FLEXArgumentInputObjectView.h in Headers */,
 				3A4C94F11B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.h in Headers */,
 				779B1ED61C0C4D7C001F5E49 /* FLEXTableContentViewController.h in Headers */,
 				3A4C94C91B5B21410088C3F2 /* FLEXDefaultsExplorerViewController.h in Headers */,
@@ -1014,7 +1014,7 @@
 				3A4C950E1B5B21410088C3F2 /* FLEXIvarEditorViewController.m in Sources */,
 				C3DC287C223ED5F200F48AA6 /* FLEXOSLogController.m in Sources */,
 				3A4C95101B5B21410088C3F2 /* FLEXMethodCallingViewController.m in Sources */,
-				3A4C94F61B5B21410088C3F2 /* FLEXArgumentInputJSONObjectView.m in Sources */,
+				3A4C94F61B5B21410088C3F2 /* FLEXArgumentInputObjectView.m in Sources */,
 				3A4C94EC1B5B21410088C3F2 /* FLEXImagePreviewViewController.m in Sources */,
 				3A4C94F21B5B21410088C3F2 /* FLEXArgumentInputFontsPickerView.m in Sources */,
 				7349FD6B22B93CDF00051810 /* FLEXColor.m in Sources */,


### PR DESCRIPTION
Currently, if argument type is `id`, there's no way to pass anything that can't be parsed from JSON.
This change adds the ability to select the type of argument to pass:
* Value - works the same as before, JSON from input string is parsed to NSDictionary/NSArray/NSString/etc.
* Address - uses object at the specified address, so you can call any method with object you previously created and populated to your preference

<img width="30%" height="30%" src="https://user-images.githubusercontent.com/4434680/56090784-9266a900-5eaf-11e9-9b7b-8caad9d92912.png">

Here's a simple demonstration of how it works:
https://streamable.com/hcwo6