### PR TITLE
I have added contact information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,20 @@
 # Contributing to FLEX #
 
 We welcome contributions! Please open a pull request with your changes. 
+
+Additionally, if you have any questions, feel free to reach out to one of the contributors listed below. The following contributors have made multiple contributions to the project and may be able to help with your questions:
+
+Ryan Olson:      https://github.com/ryanolsonk
+
+Tanner Bennet:   https://github.com/NSExceptional 
+                 tannerbennett@me.com
+                 
+Javier Soto:     https://github.com/JaviSoto
+                 ios@javisoto.es
+                 
+Tim Oliver:      https://github.com/TimOliver
+
+Daidouji Chen:   https://github.com/DaidoujiChen
+                 daidoujichen@gmail.com
+                 
+


### PR DESCRIPTION
There are no immediately obvious links to the contact information for any of the most prolific contributors.  It may be nice for some new contributors to be able to easily contact someone with questions.