### PR TITLE
Dark Mode: Add support for icons

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
@@ -6,6 +6,7 @@
 //
 //
 
+#import "FLEXColor.h"
 #import "FLEXArgumentInputTextView.h"
 #import "FLEXUtility.h"
 
@@ -24,8 +25,8 @@
     if (self) {
         self.inputTextView = [[UITextView alloc] init];
         self.inputTextView.font = [[self class] inputFont];
-        self.inputTextView.backgroundColor = [UIColor whiteColor];
-        self.inputTextView.layer.borderColor = [[UIColor blackColor] CGColor];
+        self.inputTextView.backgroundColor = [FLEXColor systemBackgroundColor];
+        self.inputTextView.layer.borderColor = [[FLEXColor borderColor] CGColor];
         self.inputTextView.layer.borderWidth = 1.0;
         self.inputTextView.autocapitalizationType = UITextAutocapitalizationTypeNone;
         self.inputTextView.autocorrectionType = UITextAutocorrectionTypeNo;
@@ -108,6 +109,18 @@
     CGSize fitSize = [super sizeThatFits:size];
     fitSize.height += [self inputTextViewHeight];
     return fitSize;
+}
+
+#pragma mark - Trait collection changes
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+#if FLEX_AT_LEAST_IOS13_SDK
+    if (@available(iOS 13.0, *)) {
+        if (previousTraitCollection.userInterfaceStyle != self.traitCollection.userInterfaceStyle) {
+            self.inputTextView.layer.borderColor = [[FLEXColor borderColor] CGColor];
+        }
+    }
+#endif
 }
 
 

--- a/Classes/Toolbar/FLEXExplorerToolbar.m
+++ b/Classes/Toolbar/FLEXExplorerToolbar.m
@@ -48,6 +48,7 @@
         
         UIImage *dragHandle = [FLEXResources dragHandle];
         self.dragHandleImageView = [[UIImageView alloc] initWithImage:dragHandle];
+        self.dragHandleImageView.tintColor = [FLEXColor iconColor];
         [self.dragHandle addSubview:self.dragHandleImageView];
         
         UIImage *globalsIcon = [FLEXResources globeIcon];

--- a/Classes/Toolbar/FLEXToolbarItem.m
+++ b/Classes/Toolbar/FLEXToolbarItem.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
+#import "FLEXColor.h"
 #import "FLEXToolbarItem.h"
 #import "FLEXUtility.h"
 
@@ -37,6 +38,7 @@
     toolbarItem.image = image;
     [toolbarItem setAttributedTitle:attributedTitle forState:UIControlStateNormal];
     [toolbarItem setImage:image forState:UIControlStateNormal];
+    [toolbarItem.imageView setTintColor:[FLEXColor iconColor]];
     return toolbarItem;
 }
 

--- a/Classes/Utility/FLEXColor.h
+++ b/Classes/Utility/FLEXColor.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 // UI element colors
 + (UIColor *)scrollViewBackgroundColor;
 + (UIColor *)iconColor;
++ (UIColor *)borderColor;
 
 @end
 

--- a/Classes/Utility/FLEXColor.h
+++ b/Classes/Utility/FLEXColor.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // UI element colors
 + (UIColor *)scrollViewBackgroundColor;
++ (UIColor *)iconColor;
 
 @end
 

--- a/Classes/Utility/FLEXColor.h
+++ b/Classes/Utility/FLEXColor.h
@@ -13,14 +13,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLEXColor : NSObject
 
+// Background colors
 + (UIColor *)systemBackgroundColor;
 + (UIColor *)systemBackgroundColorWithAlpha:(CGFloat)alpha;
+
 + (UIColor *)secondaryBackgroundColor;
 + (UIColor *)secondaryBackgroundColorWithAlpha:(CGFloat)alpha;
-+ (UIColor *)scrollViewBackgroundColor;
 
+// Text colors
 + (UIColor *)primaryTextColor;
 + (UIColor *)deemphasizedTextColor;
+
+// UI element colors
++ (UIColor *)scrollViewBackgroundColor;
 
 @end
 

--- a/Classes/Utility/FLEXColor.m
+++ b/Classes/Utility/FLEXColor.m
@@ -63,4 +63,9 @@ static UIColor *colorWithDynamicProvider(UIColor *lightColor, UIColor *darkColor
                                     [UIColor colorWithRed:16.0/255.0 green:16.0/255.0 blue:11.0/255.0 alpha:1.0]);
 }
 
++ (UIColor *)iconColor {
+    return colorWithDynamicProvider([UIColor darkGrayColor],
+                                    [UIColor lightGrayColor]);
+}
+
 @end

--- a/Classes/Utility/FLEXColor.m
+++ b/Classes/Utility/FLEXColor.m
@@ -24,6 +24,8 @@ static UIColor *colorWithDynamicProvider(UIColor *lightColor, UIColor *darkColor
     return lightColor;
 }
 
+#pragma mark - Background Colors
+
 + (UIColor *)systemBackgroundColor {
     return [self systemBackgroundColorWithAlpha:1.0];
 }
@@ -42,10 +44,7 @@ static UIColor *colorWithDynamicProvider(UIColor *lightColor, UIColor *darkColor
                                     [UIColor colorWithWhite:0.1 alpha:alpha]);
 }
 
-+ (UIColor *)scrollViewBackgroundColor {
-    return colorWithDynamicProvider([UIColor colorWithRed:239.0/255.0 green:239.0/255.0 blue:244.0/255.0 alpha:1.0],
-                                    [UIColor colorWithRed:16.0/255.0 green:16.0/255.0 blue:11.0/255.0 alpha:1.0]);
-}
+#pragma mark - Text colors
 
 + (UIColor *)primaryTextColor {
     return colorWithDynamicProvider([UIColor blackColor],
@@ -55,6 +54,13 @@ static UIColor *colorWithDynamicProvider(UIColor *lightColor, UIColor *darkColor
 + (UIColor *)deemphasizedTextColor {
     return colorWithDynamicProvider([UIColor lightGrayColor],
                                     [UIColor darkGrayColor]);
+}
+
+#pragma mark - UI Element Colors
+
++ (UIColor *)scrollViewBackgroundColor {
+    return colorWithDynamicProvider([UIColor colorWithRed:239.0/255.0 green:239.0/255.0 blue:244.0/255.0 alpha:1.0],
+                                    [UIColor colorWithRed:16.0/255.0 green:16.0/255.0 blue:11.0/255.0 alpha:1.0]);
 }
 
 @end

--- a/Classes/Utility/FLEXColor.m
+++ b/Classes/Utility/FLEXColor.m
@@ -68,4 +68,9 @@ static UIColor *colorWithDynamicProvider(UIColor *lightColor, UIColor *darkColor
                                     [UIColor lightGrayColor]);
 }
 
++ (UIColor *)borderColor {
+    return colorWithDynamicProvider([UIColor blackColor],
+                                    [UIColor whiteColor]);
+}
+
 @end

--- a/Classes/Utility/FLEXResources.m
+++ b/Classes/Utility/FLEXResources.m
@@ -87,41 +87,43 @@ static const u_int8_t FLEXBinaryIcon2x[] = {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 
     [self imageWithBytesNoCopy:(void *)base##2x length:sizeof(base##2x) scale:2.0] : \
     [self imageWithBytesNoCopy:(void *)base length:sizeof(base) scale:1.0])
 
+#define FLEXImageTemplate(base) ([FLEXImage(base) imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate])
+
 #define FLEXRetinaOnlyImage(base) ([self imageWithBytesNoCopy:(void *)(base) length:sizeof(base) scale:2.0])
 
 + (UIImage *)closeIcon
 {
-    return FLEXImage(FLEXCloseIcon);
+    return FLEXImageTemplate(FLEXCloseIcon);
 }
 
 + (UIImage *)dragHandle
 {
-    return FLEXImage(FLEXDragHandle);
+    return FLEXImageTemplate(FLEXDragHandle);
 }
 
 + (UIImage *)globeIcon
 {
-    return FLEXImage(FLEXGlobeIcon);
+    return FLEXImageTemplate(FLEXGlobeIcon);
 }
 
 + (UIImage *)hierarchyIndentPattern
 {
-    return FLEXImage(FLEXHierarchyIndentPattern);
+    return FLEXImageTemplate(FLEXHierarchyIndentPattern);
 }
 
 + (UIImage *)listIcon
 {
-    return FLEXImage(FLEXListIcon);
+    return FLEXImageTemplate(FLEXListIcon);
 }
 
 + (UIImage *)moveIcon
 {
-    return FLEXImage(FLEXMoveIcon);
+    return FLEXImageTemplate(FLEXMoveIcon);
 }
 
 + (UIImage *)selectIcon
 {
-    return FLEXImage(FLEXSelectIcon);
+    return FLEXImageTemplate(FLEXSelectIcon);
 }
 
 + (UIImage *)jsonIcon

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
+#import "FLEXColor.h"
 #import "FLEXUtility.h"
 #import "FLEXResources.h"
 #import <ImageIO/ImageIO.h>
@@ -95,7 +96,26 @@
     dispatch_once(&onceToken, ^{
         UIImage *indentationPatternImage = [FLEXResources hierarchyIndentPattern];
         patternColor = [UIColor colorWithPatternImage:indentationPatternImage];
+
+#if FLEX_AT_LEAST_IOS13_SDK
+        if (@available(iOS 13.0, *)) {
+            // Create a dark mode version
+            UIGraphicsBeginImageContextWithOptions(indentationPatternImage.size, NO, indentationPatternImage.scale);
+            [[FLEXColor iconColor] set];
+            [indentationPatternImage drawInRect:CGRectMake(0, 0, indentationPatternImage.size.width, indentationPatternImage.size.height)];
+            UIImage *darkModePatternImage = UIGraphicsGetImageFromCurrentImageContext();
+            UIGraphicsEndImageContext();
+
+            // Create dynamic color provider
+            patternColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
+                return (traitCollection.userInterfaceStyle == UIUserInterfaceStyleLight
+                        ? [UIColor colorWithPatternImage:indentationPatternImage]
+                        : [UIColor colorWithPatternImage:darkModePatternImage]);
+            }];
+        }
+#endif
     });
+
     return patternColor;
 }
 


### PR DESCRIPTION
In this PR, we add support for dark mode to the icons. It loads the icons as templates and uses tint color to support dark mode.

Also in this PR:
* Updated hierarchy indicator to support dark mode
* Reorganized `FLEXColor`

-----

## Toolbar

Light:
<img width=50% height=50% src=https://user-images.githubusercontent.com/5719/59773961-8ff04900-927c-11e9-8169-f03353209437.png>

Dark:
<img width=50% height=50% src=https://user-images.githubusercontent.com/5719/59773975-954d9380-927c-11e9-8b7d-47e0bff5f0c5.png>

---

## Hierarchy Indicator

Light:
<img width=50% height=50% src=https://user-images.githubusercontent.com/5719/59773995-a39baf80-927c-11e9-93d9-6954fafda181.png>

Dark:
<img width=50% height=50% src=https://user-images.githubusercontent.com/5719/59774004-a7c7cd00-927c-11e9-9c41-d94be2ac3685.png>
