### PR TITLE
Fix struct field offset calculation when enumerating struct encoding

### DIFF
--- a/Classes/Utility/FLEXRuntimeUtility.m
+++ b/Classes/Utility/FLEXRuntimeUtility.m
@@ -624,13 +624,14 @@ const unsigned int kFLEXNumberOfImplicitArgs = 2;
                     // If the struct type encoding was successfully handled by NSGetSizeAndAlignment above, we *should* be ok with the field here.
                     const char *nextTypeStart = NSGetSizeAndAlignment(typeStart, &fieldSize, NULL);
                     NSString *typeEncoding = [@(structEncoding) substringWithRange:NSMakeRange(typeStart - structEncoding, nextTypeStart - typeStart)];
-                    typeBlock(structName, typeEncoding.UTF8String, [self readableTypeForEncoding:typeEncoding], runningFieldIndex, runningFieldOffset);
-                    runningFieldOffset += fieldSize;
                     // Padding to keep proper alignment. __attribute((packed)) structs will break here.
                     // The type encoding is no different for packed structs, so it's not clear there's anything we can do for those.
-                    if (runningFieldOffset % fieldAlignment != 0) {
-                        runningFieldOffset += fieldAlignment - runningFieldOffset % fieldAlignment;
+                    const NSUInteger currentSizeSum = runningFieldOffset % fieldAlignment;
+                    if (currentSizeSum != 0 && currentSizeSum + fieldSize > fieldAlignment) {
+                        runningFieldOffset += fieldAlignment - currentSizeSum;
                     }
+                    typeBlock(structName, typeEncoding.UTF8String, [self readableTypeForEncoding:typeEncoding], runningFieldIndex, runningFieldOffset);
+                    runningFieldOffset += fieldSize;
                     runningFieldIndex++;
                     typeStart = nextTypeStart;
                 }


### PR DESCRIPTION
For structures like this
```
typedef struct SomeStruct {
  double a;
  int b;
  int c;
  double d;
} SomeStruct;
```

Before this change, the `runningFieldOffset` for `a`, `b,` `c`, `d` will be `0, 8, 16, 24` respectively, which is wrong.

My understanding for `alignmentPadding` is we need to add it for the current running field only if the current field will overflow the `fieldAlignment`. So in this example the two ints `b` and `c` are actually stays in the same 8 bytes.

After this change, the `runningFieldOffset` for `a`, `b,` `c`, `d` will be `0, 8, 12, 16` respectively, which is correct.

I have tested using this for printing out the struct values and it is now correct.