### PR TITLE
Add named struct field parsing support to fix the struct iVar issues

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputViewFactory.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputViewFactory.m
@@ -17,6 +17,7 @@
 #import "FLEXArgumentInputFontView.h"
 #import "FLEXArgumentInputColorView.h"
 #import "FLEXArgumentInputDateView.h"
+#import "FLEXRuntimeUtility.h"
 
 @implementation FLEXArgumentInputViewFactory
 
@@ -33,11 +34,15 @@
         // The unsupported view shows "nil" and does not allow user input.
         subclass = [FLEXArgumentInputNotSupportedView class];
     }
-    return [[subclass alloc] initWithArgumentTypeEncoding:typeEncoding];
+    // Remove the field name if there is any (e.g. \"width\"d -> d)
+    const NSUInteger fieldNameOffset = [FLEXRuntimeUtility fieldNameOffsetForTypeEncoding:typeEncoding];
+    return [[subclass alloc] initWithArgumentTypeEncoding:typeEncoding + fieldNameOffset];
 }
 
 + (Class)argumentInputViewSubclassForTypeEncoding:(const char *)typeEncoding currentValue:(id)currentValue
 {
+    // Remove the field name if there is any (e.g. \"width\"d -> d)
+    const NSUInteger fieldNameOffset = [FLEXRuntimeUtility fieldNameOffsetForTypeEncoding:typeEncoding];
     Class argumentInputViewSubclass = nil;
     NSArray<Class> *inputViewClasses = @[[FLEXArgumentInputColorView class],
                                          [FLEXArgumentInputFontView class],
@@ -47,17 +52,17 @@
                                          [FLEXArgumentInputDateView class],
                                          [FLEXArgumentInputNumberView class],
                                          [FLEXArgumentInputObjectView class]];
-    
+
     // Note that order is important here since multiple subclasses may support the same type.
     // An example is the number subclass and the bool subclass for the type @encode(BOOL).
     // Both work, but we'd prefer to use the bool subclass.
-    for (Class inputView in inputViewClasses) {
-        if ([inputView supportsObjCType:typeEncoding withCurrentValue:currentValue]) {
-            argumentInputViewSubclass = inputView;
+    for (Class inputViewClass in inputViewClasses) {
+        if ([inputViewClass supportsObjCType:typeEncoding + fieldNameOffset withCurrentValue:currentValue]) {
+            argumentInputViewSubclass = inputViewClass;
             break;
         }
     }
-    
+
     return argumentInputViewSubclass;
 }
 

--- a/Classes/Utility/FLEXRuntimeUtility.h
+++ b/Classes/Utility/FLEXRuntimeUtility.h
@@ -52,6 +52,7 @@ typedef NS_ENUM(char, FLEXTypeEncoding)
     FLEXTypeEncodingStructEnd        = '}',
     FLEXTypeEncodingUnionBegin       = '(',
     FLEXTypeEncodingUnionEnd         = ')',
+    FLEXTypeEncodingQuote            = '\"',
     FLEXTypeEncodingBitField         = 'b',
     FLEXTypeEncodingPointer          = '^',
     FLEXTypeEncodingConst            = 'r'
@@ -66,6 +67,9 @@ typedef NS_ENUM(char, FLEXTypeEncoding)
 + (BOOL)pointerIsValidObjcObject:(const void *)pointer;
 /// Unwraps raw pointers to objects stored in NSValue, and re-boxes C strings into NSStrings.
 + (id)potentiallyUnwrapBoxedPointer:(id)returnedObjectOrNil type:(const FLEXTypeEncoding *)returnType;
+/// Some fields have a name in their encoded string (e.g. \"width\"d)
+/// @return the offset to skip the field name, 0 if there is no name
++ (NSUInteger)fieldNameOffsetForTypeEncoding:(const FLEXTypeEncoding *)typeEncoding;
 
 /// @return The class hierarchy for the given object or class,
 /// from the current class to the root-most class.


### PR DESCRIPTION
Right now the struct parsing logic in FLEX doesn't support named fields.
A simple example like:
```
typedef struct TestSize {
    double width;
    double height;
} TestSize;
```
would be shown like this in FLEX:
<img width=50% height=50% src=https://user-images.githubusercontent.com/627231/63231377-a741a900-c1cf-11e9-8982-d69f060dcb8f.png>

The type encoding string is `{TestSize="width"d"height"d}`. However FLEX doesn't support the named fields in the parsing logic.

This PR tried to support the basic parsing support to make sure we can render both field name and field value properly. This would greatly help debugging C structs in general.

After the patch, this is how looks like for the same structs:
<img width=50% height=50% src=https://user-images.githubusercontent.com/627231/63231390-f556ac80-c1cf-11e9-9f26-ad873f4c557d.png>

Most of the new code has inline comments.
Here are some references I looked at when implementing this:
- https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
- https://github.com/opensource-apple/objc4/blob/cd5e62a5597ea7a31dccef089317abb3a661c154/runtime/objc-layout.mm
- https://github.com/nygard/class-dump/blob/master/Source/CDTypeParser.m

Also this depends on #315, otherwise the we will get wrong values.