### PR TITLE
Try unwrap boxed value before set to input value for iVar and property input view

### DIFF
--- a/Classes/Editing/FLEXIvarEditorViewController.m
+++ b/Classes/Editing/FLEXIvarEditorViewController.m
@@ -36,10 +36,13 @@
     [super viewDidLoad];
     
     self.fieldEditorView.fieldDescription = [FLEXRuntimeUtility prettyNameForIvar:self.ivar];
-    
-    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:ivar_getTypeEncoding(self.ivar)];
+
+    const char *typeEncoding = ivar_getTypeEncoding(self.ivar);
+    id currentValue = [FLEXRuntimeUtility valueForIvar:self.ivar onObject:self.target];
+    currentValue = [FLEXRuntimeUtility potentiallyUnwrapBoxedPointer:currentValue type:typeEncoding];
+    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:typeEncoding currentValue:currentValue];
     inputView.backgroundColor = self.view.backgroundColor;
-    inputView.inputValue = [FLEXRuntimeUtility valueForIvar:self.ivar onObject:self.target];
+    inputView.inputValue = currentValue;
     inputView.delegate = self;
     self.fieldEditorView.argumentInputViews = @[inputView];
     

--- a/Classes/Editing/FLEXPropertyEditorViewController.m
+++ b/Classes/Editing/FLEXPropertyEditorViewController.m
@@ -36,16 +36,18 @@
     [super viewDidLoad];
     
     self.fieldEditorView.fieldDescription = [FLEXRuntimeUtility fullDescriptionForProperty:self.property];
-    id currentValue = [FLEXRuntimeUtility valueForProperty:self.property onObject:self.target];
-    self.setterButton.enabled = [[self class] canEditProperty:self.property onObject:self.target currentValue:currentValue];
-    
+
     const char *typeEncoding = [FLEXRuntimeUtility typeEncodingForProperty:self.property].UTF8String;
-    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:typeEncoding];
+    id currentValue = [FLEXRuntimeUtility valueForProperty:self.property onObject:self.target];
+    currentValue = [FLEXRuntimeUtility potentiallyUnwrapBoxedPointer:currentValue type:typeEncoding];
+    FLEXArgumentInputView *inputView = [FLEXArgumentInputViewFactory argumentInputViewForTypeEncoding:typeEncoding currentValue:currentValue];
     inputView.backgroundColor = self.view.backgroundColor;
-    inputView.inputValue = [FLEXRuntimeUtility valueForProperty:self.property onObject:self.target];
+    inputView.inputValue = currentValue;
     inputView.delegate = self;
     self.fieldEditorView.argumentInputViews = @[inputView];
-    
+
+    self.setterButton.enabled = [[self class] canEditProperty:self.property onObject:self.target currentValue:currentValue];
+
     // Don't show a "set" button for switches - just call the setter immediately after the switch toggles.
     if ([inputView isKindOfClass:[FLEXArgumentInputSwitchView class]]) {
         self.navigationItem.rightBarButtonItem = nil;


### PR DESCRIPTION
Fixed `FLEXIvarEditorViewController` and `FLEXPropertyEditorViewController`

For instance variable type `const char *`, there are two issues in FLEX right now:
1. The `FLEXIvarEditorViewController` uses `FLEXArgumentInputNotSupportedView` because it didn't pass in its current value. And `FLEXArgumentInputStringView` only supports `NSString` type or `NSString` values.
2. The value will be a `NSValue` pointing to the `char *` pointer. 
However when we set this `NSValue` to `FLEXArgumentInputStringView`, it's not able to render it wasn't unwrapped.

This PR fixed both issues. The similar logic can be found here: https://github.com/Flipboard/FLEX/blob/bff9f1dd898fd723cacad39cd8014d13758e29f6/Classes/ObjectExplorers/Controllers/FLEXObjectExplorerViewController.m#L380-L381
