### PR TITLE
Add long double support in FLEXRuntimeUtility

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNumberView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNumberView.m
@@ -49,7 +49,8 @@
                            @(@encode(unsigned long)),
                            @(@encode(unsigned long long)),
                            @(@encode(float)),
-                           @(@encode(double))];
+                           @(@encode(double)),
+                           @(@encode(long double))];
     });
     return type && [primitiveTypes containsObject:@(type)];
 }

--- a/Classes/Utility/FLEXRuntimeUtility.h
+++ b/Classes/Utility/FLEXRuntimeUtility.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(char, FLEXTypeEncoding)
     FLEXTypeEncodingUnsignedLongLong = 'Q',
     FLEXTypeEncodingFloat            = 'f',
     FLEXTypeEncodingDouble           = 'd',
+    FLEXTypeEncodingLongDouble       = 'D',
     FLEXTypeEncodingCBool            = 'B',
     FLEXTypeEncodingVoid             = 'v',
     FLEXTypeEncodingCString          = '*',

--- a/Classes/Utility/FLEXRuntimeUtility.m
+++ b/Classes/Utility/FLEXRuntimeUtility.m
@@ -595,6 +595,9 @@ const unsigned int kFLEXNumberOfImplicitArgs = 2;
     } else if (strcmp(typeEncoding, @encode(double)) == 0) {
         double primitiveValue = [number doubleValue];
         value = [NSValue value:&primitiveValue withObjCType:typeEncoding];
+    } else if (strcmp(typeEncoding, @encode(long double)) == 0) {
+      long double primitiveValue = [number doubleValue];
+      value = [NSValue value:&primitiveValue withObjCType:typeEncoding];
     }
 
     return value;
@@ -784,6 +787,7 @@ const unsigned int kFLEXNumberOfImplicitArgs = 2;
     CASE(unsigned long long, UnsignedLongLong);
     CASE(float, Float);
     CASE(double, Double);
+    CASE(long double, Double);
 
 #undef CASE
 


### PR DESCRIPTION
Add long double support in `FLEXRuntimeUtility`.

The only downside for this one is that the `NSNumber` doesn't support `long double`. However it was saying on iOS, the `sizeof(double) == sizeof(long double)`, so probably it's fine.