### PR TITLE
Fix #324, crash when viewing NSNumber

### DIFF
--- a/Classes/GlobalStateExplorers/FLEXInstancesTableViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXInstancesTableViewController.m
@@ -61,7 +61,8 @@
     NSMutableArray *instances = [NSMutableArray array];
     [FLEXHeapEnumerator enumerateLiveObjectsUsingBlock:^(__unsafe_unretained id object, __unsafe_unretained Class actualClass) {
         if (strcmp(classNameCString, class_getName(actualClass)) == 0) {
-            // Note: objects of certain classes crash when retain is called. It is up to the user to avoid tapping into instance lists for these classes.
+            // Note: objects of certain classes crash when retain is called.
+            // It is up to the user to avoid tapping into instance lists for these classes.
             // Ex. OS_dispatch_queue_specific_queue
             // In the future, we could provide some kind of warning for classes that are known to be problematic.
             if (malloc_size((__bridge const void *)(object)) > 0) {


### PR DESCRIPTION
Now, we check for return length before even trying to invoke a method. If the length is 0 we abort. The length will be 0 for any unsupported type encoding such as that of `NSDecimal` or anything with bitfields or inline arrays.