### PR TITLE
Fix heap enumeration on arm64e devices

### DIFF
--- a/Classes/Utility/Categories/NSObject+FLEX_Reflection.h
+++ b/Classes/Utility/Categories/NSObject+FLEX_Reflection.h
@@ -34,6 +34,8 @@ NSArray<FLEXProperty *> *FLEXGetAllProperties(_Nullable Class cls);
 /// @param instance used to mark methods as instance methods or not.
 /// Not used to determine whether to get instance or class methods. 
 NSArray<FLEXMethod *> *FLEXGetAllMethods(_Nullable Class cls, BOOL instance);
+/// @param cls a class object to get all instance and class methods.
+NSArray<FLEXMethod *> *FLEXGetAllInstanceAndClassMethods(_Nullable Class cls);
 
 
 

--- a/Classes/Utility/Runtime/Objc/FLEXObjcInternal.h
+++ b/Classes/Utility/Runtime/Objc/FLEXObjcInternal.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+BOOL FLEXPointerIsReadable(const void *inPtr);
+
 /// @brief Assumes memory is valid and readable.
 /// @discussion objc-internal.h, objc-private.h, and objc-config.h
 /// https://blog.timac.org/2016/1124-testing-if-an-arbitrary-pointer-is-a-valid-objective-c-object/

--- a/Classes/Utility/Runtime/Objc/FLEXTypeEncodingParser.m
+++ b/Classes/Utility/Runtime/Objc/FLEXTypeEncodingParser.m
@@ -546,10 +546,15 @@ BOOL FLEXGetSizeAndAlignment(const char *type, NSUInteger *sizep, NSUInteger *al
 }
 
 - (BOOL)canScanChar:(char)c {
-    NSScanner *scan = self.scan;
-    if (scan.scanLocation >= scan.string.length) return NO;
+    // By avoiding any ARC calls on these two objects which we know won't be
+    // free'd out from under us, we're making HUGE performance savings in this
+    // parser, because this method is one of the most-used methods of the parser.
+    // This is probably the most performance-critical method in this class.
+    __unsafe_unretained NSScanner *scan = self.scan;
+    __unsafe_unretained NSString *string = scan.string;
+    if (scan.scanLocation >= string.length) return NO;
     
-    return [scan.string characterAtIndex:scan.scanLocation] == c;
+    return [string characterAtIndex:scan.scanLocation] == c;
 }
 
 - (BOOL)scanChar:(char)c {

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXMethod.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXMethod.m
@@ -14,6 +14,7 @@
 #include <dlfcn.h>
 
 @implementation FLEXMethod
+@synthesize imagePath = _imagePath;
 @dynamic implementation;
 
 + (instancetype)buildMethodNamed:(NSString *)name withTypes:(NSString *)typeEncoding implementation:(IMP)implementation {
@@ -156,11 +157,6 @@
     _name              = NSStringFromSelector(_selector);
     _returnType        = (FLEXTypeEncoding *)_signature.methodReturnType ?: "";
     _returnSize        = _signature.methodReturnLength;
-    
-    Dl_info exeInfo;
-    if (dladdr(_objc_method, &exeInfo)) {
-        _imagePath = exeInfo.dli_fname ? @(exeInfo.dli_fname) : nil;
-    }
 }
 
 #pragma mark Public
@@ -182,6 +178,17 @@
     }
     
     return _typeEncoding;
+}
+
+- (NSString *)imagePath {
+    if (!_imagePath) {
+        Dl_info exeInfo;
+        if (dladdr(_objc_method, &exeInfo)) {
+            _imagePath = exeInfo.dli_fname ? @(exeInfo.dli_fname) : @"";
+        }
+    }
+    
+    return _imagePath;
 }
 
 #pragma mark Misc


### PR DESCRIPTION
This was previously discussed here: https://github.com/NSExceptional/FLEXing/issues/7

This solution seems to work 100% of the time, so I am assuming that locking and unlocking the zones is no longer needed on arm64e. It might be a good idea to confirm it however.

(Only applies for apps that have an arm64e slice, arm64 apps running on an arm64e device are not affected)