### PR TITLE
Fix stack memory being used in async block

### DIFF
--- a/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
@@ -178,9 +178,11 @@ static uint8_t (*OSLogGetType)(void *);
             if (entry->log_message.format && !(strcmp(entry->log_message.format, messageText))) {
                 messageText = (char *)entry->log_message.format;
             }
+            // move messageText from stack to heap
+            NSString *msg = [NSString stringWithUTF8String:messageText];
 
             dispatch_async(dispatch_get_main_queue(), ^{
-                FLEXSystemLogMessage *message = [FLEXSystemLogMessage logMessageFromDate:date text:@(messageText)];
+                FLEXSystemLogMessage *message = [FLEXSystemLogMessage logMessageFromDate:date text:msg];
                 if (self.persistent) {
                     [self.messages addObject:message];
                 }


### PR DESCRIPTION
The address of the messageText variable  is in the stack, when use disaptch_async, it will released.