### PR TITLE
Address "This block declaration is not a prototype" warning

### DIFF
--- a/Classes/Core/FLEXScopeCarousel.m
+++ b/Classes/Core/FLEXScopeCarousel.m
@@ -76,7 +76,7 @@ NSString * const kCarouselCellReuseIdentifier = @"kCarouselCellReuseIdentifier";
 
                 // Notify observers
                 __typeof(self) self = weakSelf;
-                for (void (^block)() in self.dynamicTypeHandlers) {
+                for (void (^block)(FLEXScopeCarousel *) in self.dynamicTypeHandlers) {
                     block(self);
                 }
             }

--- a/Classes/Core/FLEXTableViewController.h
+++ b/Classes/Core/FLEXTableViewController.h
@@ -89,6 +89,6 @@ extern CGFloat const kFLEXDebounceForExpensiveIO;
 
 /// Convenient for doing some async processor-intensive searching
 /// in the background before updating the UI back on the main queue.
-- (void)onBackgroundQueue:(NSArray *(^)())backgroundBlock thenOnMainQueue:(void(^)(NSArray *))mainBlock;
+- (void)onBackgroundQueue:(NSArray *(^)(void))backgroundBlock thenOnMainQueue:(void(^)(NSArray *))mainBlock;
 
 @end

--- a/Classes/Core/FLEXTableViewController.m
+++ b/Classes/Core/FLEXTableViewController.m
@@ -127,7 +127,7 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
 
 - (void)updateSearchResults:(NSString *)newText { }
 
-- (void)onBackgroundQueue:(NSArray *(^)())backgroundBlock thenOnMainQueue:(void(^)(NSArray *))mainBlock {
+- (void)onBackgroundQueue:(NSArray *(^)(void))backgroundBlock thenOnMainQueue:(void(^)(NSArray *))mainBlock {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSArray *items = backgroundBlock();
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -173,7 +173,7 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
 
 #pragma mark - Private
 
-- (void)debounce:(void(^)())block {
+- (void)debounce:(void(^)(void))block {
     [self.debounceTimer invalidate];
     
     self.debounceTimer = [NSTimer

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainQuery.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainQuery.m
@@ -182,7 +182,7 @@
 #ifdef FLEXKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 + (BOOL)isSynchronizationAvailable {
 #if TARGET_OS_IPHONE
-    return @available(iOS 7.0, *);
+    return YES;
 #else
     return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_8_4;
 #endif

--- a/Classes/ObjectExplorers/Views/FLEXTableView.m
+++ b/Classes/ObjectExplorers/Views/FLEXTableView.m
@@ -18,13 +18,9 @@
 
 - (CGFloat)_heightForHeaderInSection:(NSInteger)section {
     CGFloat height = [super _heightForHeaderInSection:section];
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsupported-availability-guard"
     if (section == 0 && self.tableHeaderView && !@available(iOS 13.0, *)) {
         return height - self.tableHeaderView.frame.size.height + 8;
     }
-#pragma clang diagnostic pop
 
     return height;
 }

--- a/Classes/ObjectExplorers/Views/FLEXTableView.m
+++ b/Classes/ObjectExplorers/Views/FLEXTableView.m
@@ -18,8 +18,10 @@
 
 - (CGFloat)_heightForHeaderInSection:(NSInteger)section {
     CGFloat height = [super _heightForHeaderInSection:section];
-    if (section == 0 && self.tableHeaderView && !@available(iOS 13.0, *)) {
-        return height - self.tableHeaderView.frame.size.height + 8;
+    if (section == 0 && self.tableHeaderView) {
+        if (@available(iOS 13.0, *)) {} else {
+            return height - self.tableHeaderView.frame.size.height + 8;
+        }
     }
 
     return height;

--- a/Classes/ObjectExplorers/Views/FLEXTableView.m
+++ b/Classes/ObjectExplorers/Views/FLEXTableView.m
@@ -18,11 +18,13 @@
 
 - (CGFloat)_heightForHeaderInSection:(NSInteger)section {
     CGFloat height = [super _heightForHeaderInSection:section];
-    if (section == 0 && self.tableHeaderView) {
-        if (@available(iOS 13.0, *)) {} else {
-            return height - self.tableHeaderView.frame.size.height + 8;
-        }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsupported-availability-guard"
+    if (section == 0 && self.tableHeaderView && !@available(iOS 13.0, *)) {
+        return height - self.tableHeaderView.frame.size.height + 8;
     }
+#pragma clang diagnostic pop
 
     return height;
 }

--- a/Classes/Utility/FLEXAlert.h
+++ b/Classes/Utility/FLEXAlert.h
@@ -10,14 +10,14 @@
 
 @class FLEXAlert, FLEXAlertAction;
 
-typedef void (^FLEXAlertReveal)();
+typedef void (^FLEXAlertReveal)(void);
 typedef void (^FLEXAlertBuilder)(FLEXAlert *make);
 typedef FLEXAlert *(^FLEXAlertStringProperty)(NSString *);
 typedef FLEXAlert *(^FLEXAlertStringArg)(NSString *);
 typedef FLEXAlert *(^FLEXAlertTextField)(void(^configurationHandler)(UITextField *textField));
 typedef FLEXAlertAction *(^FLEXAlertAddAction)(NSString *title);
 typedef FLEXAlertAction *(^FLEXAlertActionStringProperty)(NSString *);
-typedef FLEXAlertAction *(^FLEXAlertActionProperty)();
+typedef FLEXAlertAction *(^FLEXAlertActionProperty)(void);
 typedef FLEXAlertAction *(^FLEXAlertActionBOOLProperty)(BOOL);
 typedef FLEXAlertAction *(^FLEXAlertActionHandler)(void(^handler)(NSArray<NSString *> *strings));
 


### PR DESCRIPTION
1. This block declaration is not a prototype
2. @available does not guard availability here; use if (@available) instead


We added FLEX manually to our project, we have the option `strict prototypes` enabled (YES) and we don't have in `Other warnings flags` the flag `-Wno-unsupported-availability-guard`