### PR TITLE
fixup tiny pedantic compilation issues

### DIFF
--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.h
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.h
@@ -6,9 +6,8 @@
 //  Based on previous work by Evan Doll
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
-#import "FLEXFileBrowserSearchOperation.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXFileBrowserTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.m
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "FLEXFileBrowserTableViewController.h"
+#import "FLEXFileBrowserSearchOperation.h"
 #import "FLEXUtility.h"
 #import "FLEXWebViewController.h"
 #import "FLEXImagePreviewViewController.h"

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "FLEXTableViewSection.h"
+#import <FLEX/FLEXTableViewSection.h>
+
 @class FLEXGlobalsTableViewController;
 
 typedef NS_ENUM(NSUInteger, FLEXGlobalsRow) {

--- a/Classes/ObjectExplorers/Views/FLEXTableView.m
+++ b/Classes/ObjectExplorers/Views/FLEXTableView.m
@@ -18,10 +18,13 @@
 
 - (CGFloat)_heightForHeaderInSection:(NSInteger)section {
     CGFloat height = [super _heightForHeaderInSection:section];
-    if (section == 0 && self.tableHeaderView && !@available(iOS 13.0, *)) {
+    if(@available(iOS 13.0, *)) {
+      return height;
+    }
+      
+    if (section == 0 && self.tableHeaderView) {
         return height - self.tableHeaderView.frame.size.height + 8;
     }
-
     return height;
 }
 


### PR DESCRIPTION
This commit fixes some tiny pedantic compilation issues:
- availability ‘macro’ misuse
- header search paths