### PR TITLE
fixup @available compilation issue and make all headers use <FLEX/*.h> syntax

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputColorView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputColorView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputColorView : FLEXArgumentInputView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputDateView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputDateView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputDateView : FLEXArgumentInputView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputFontView : FLEXArgumentInputView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontsPickerView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontsPickerView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014年 f. All rights reserved.
 //
 
-#import "FLEXArgumentInputTextView.h"
+#import <FLEX/FLEXArgumentInputTextView.h>
 
 @interface FLEXArgumentInputFontsPickerView : FLEXArgumentInputTextView <UIPickerViewDataSource, UIPickerViewDelegate>
 @end

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNotSupportedView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNotSupportedView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputTextView.h"
+#import <FLEX/FLEXArgumentInputTextView.h>
 
 @interface FLEXArgumentInputNotSupportedView : FLEXArgumentInputTextView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNumberView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputNumberView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputTextView.h"
+#import <FLEX/FLEXArgumentInputTextView.h>
 
 @interface FLEXArgumentInputNumberView : FLEXArgumentInputTextView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputTextView.h"
+#import <FLEX/FLEXArgumentInputTextView.h>
 
 @interface FLEXArgumentInputObjectView : FLEXArgumentInputTextView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputStringView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputStringView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputTextView.h"
+#import <FLEX/FLEXArgumentInputTextView.h>
 
 @interface FLEXArgumentInputStringView : FLEXArgumentInputTextView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputStructView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputStructView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputStructView : FLEXArgumentInputView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputSwitchView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputSwitchView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputSwitchView : FLEXArgumentInputView
 

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.h
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import "FLEXArgumentInputView.h"
+#import <FLEX/FLEXArgumentInputView.h>
 
 @interface FLEXArgumentInputTextView : FLEXArgumentInputView <UITextViewDelegate>
 

--- a/Classes/Editing/FLEXDefaultEditorViewController.h
+++ b/Classes/Editing/FLEXDefaultEditorViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXMutableFieldEditorViewController.h"
+#import <FLEX/FLEXMutableFieldEditorViewController.h>
 
 @interface FLEXDefaultEditorViewController : FLEXMutableFieldEditorViewController
 

--- a/Classes/Editing/FLEXIvarEditorViewController.h
+++ b/Classes/Editing/FLEXIvarEditorViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXMutableFieldEditorViewController.h"
+#import <FLEX/FLEXMutableFieldEditorViewController.h>
 #import <objc/runtime.h>
 
 @interface FLEXIvarEditorViewController : FLEXMutableFieldEditorViewController

--- a/Classes/Editing/FLEXMethodCallingViewController.h
+++ b/Classes/Editing/FLEXMethodCallingViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXFieldEditorViewController.h"
+#import <FLEX/FLEXFieldEditorViewController.h>
 #import <objc/runtime.h>
 
 @interface FLEXMethodCallingViewController : FLEXFieldEditorViewController

--- a/Classes/Editing/FLEXMutableFieldEditorViewController.h
+++ b/Classes/Editing/FLEXMutableFieldEditorViewController.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Flipboard. All rights reserved.
 //
 
-#import "FLEXFieldEditorViewController.h"
+#import <FLEX/FLEXFieldEditorViewController.h>
 
 @interface FLEXMutableFieldEditorViewController : FLEXFieldEditorViewController
 

--- a/Classes/Editing/FLEXPropertyEditorViewController.h
+++ b/Classes/Editing/FLEXPropertyEditorViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXMutableFieldEditorViewController.h"
+#import <FLEX/FLEXMutableFieldEditorViewController.h>
 #import <objc/runtime.h>
 
 @interface FLEXPropertyEditorViewController : FLEXMutableFieldEditorViewController

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "FLEXTableColumnHeader.h"
+#import <FLEX/FLEXTableColumnHeader.h>
 
 @class FLEXMultiColumnTableView;
 

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXRealmDatabaseManager.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "FLEXDatabaseManager.h"
+#import <FLEX/FLEXDatabaseManager.h>
 
 @interface FLEXRealmDatabaseManager : NSObject <FLEXDatabaseManager>
 

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.h
@@ -12,7 +12,7 @@
 //  which Flying Meat Inc. licenses this file to you.
 
 #import <Foundation/Foundation.h>
-#import "FLEXDatabaseManager.h"
+#import <FLEX/FLEXDatabaseManager.h>
 
 @interface FLEXSQLiteDatabaseManager : NSObject <FLEXDatabaseManager>
 

--- a/Classes/GlobalStateExplorers/FLEXAddressExplorerCoordinator.h
+++ b/Classes/GlobalStateExplorers/FLEXAddressExplorerCoordinator.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Flipboard. All rights reserved.
 //
 
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXAddressExplorerCoordinator : NSObject <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FLEXClassesTableViewController.h
+++ b/Classes/GlobalStateExplorers/FLEXClassesTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXClassesTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FLEXCookiesTableViewController.h
+++ b/Classes/GlobalStateExplorers/FLEXCookiesTableViewController.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Flipboard. All rights reserved.
 //
 
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXCookiesTableViewController : UITableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FLEXLibrariesTableViewController.h
+++ b/Classes/GlobalStateExplorers/FLEXLibrariesTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXLibrariesTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FLEXLiveObjectsTableViewController.h
+++ b/Classes/GlobalStateExplorers/FLEXLiveObjectsTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXLiveObjectsTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.h
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.h
@@ -6,9 +6,8 @@
 //  Based on previous work by Evan Doll
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
-#import "FLEXFileBrowserSearchOperation.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXFileBrowserTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.m
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserTableViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "FLEXFileBrowserTableViewController.h"
+#import "FLEXFileBrowserSearchOperation.h"
 #import "FLEXUtility.h"
 #import "FLEXWebViewController.h"
 #import "FLEXImagePreviewViewController.h"

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "FLEXTableViewSection.h"
+#import <FLEX/FLEXTableViewSection.h>
+
 @class FLEXGlobalsTableViewController;
 
 typedef NS_ENUM(NSUInteger, FLEXGlobalsRow) {

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsTableViewController.h
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsTableViewController.h
@@ -6,7 +6,8 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
+#import <FLEX/FLEXTableViewController.h>
+
 @protocol FLEXGlobalsTableViewControllerDelegate;
 
 typedef NS_ENUM(NSUInteger, FLEXGlobalsSection) {

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.h
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright © 2019 Flipboard. All rights reserved.
 //
 
-#import "FLEXGlobalsEntry.h"
-#import "FLEXTableViewController.h"
+#import <FLEX/FLEXGlobalsEntry.h>
+#import <FLEX/FLEXTableViewController.h>
 
 @interface FLEXKeychainTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXASLLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXASLLogController.m
@@ -7,6 +7,7 @@
 //
 
 #import "FLEXASLLogController.h"
+#import "FLEXSystemLogMessage.h"
 #import <asl.h>
 
 // Querying the ASL is much slower in the simulator. We need a longer polling interval to keep things responsive.

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXLogController.h
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXLogController.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "FLEXSystemLogMessage.h"
+@class FLEXSystemLogMessage;
 
 @protocol FLEXLogController <NSObject>
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
@@ -7,6 +7,8 @@
 //
 
 #import "FLEXOSLogController.h"
+
+#import "FLEXSystemLogMessage.h"
 #include <dlfcn.h>
 #include "ActivityStreamAPI.h"
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogMessage.h
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogMessage.h
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 #import <asl.h>
-#import "ActivityStreamAPI.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogTableViewController.h
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 f. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXSystemLogTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogTableViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogTableViewController.m
@@ -12,6 +12,7 @@
 #import "FLEXASLLogController.h"
 #import "FLEXOSLogController.h"
 #import "FLEXSystemLogTableViewCell.h"
+#import "FLEXSystemLogMessage.h"
 
 @interface FLEXSystemLogTableViewController ()
 

--- a/Classes/Manager/FLEXManager+Private.h
+++ b/Classes/Manager/FLEXManager+Private.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Pebble Technology. All rights reserved.
 //
 
-#import "FLEXManager.h"
+#import <FLEX/FLEXManager.h>
 
 @class FLEXGlobalsEntry;
 

--- a/Classes/Network/FLEXNetworkHistoryTableViewController.h
+++ b/Classes/Network/FLEXNetworkHistoryTableViewController.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXTableViewController.h>
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @interface FLEXNetworkHistoryTableViewController : FLEXTableViewController <FLEXGlobalsEntry>
 

--- a/Classes/Network/FLEXNetworkTransaction.h
+++ b/Classes/Network/FLEXNetworkTransaction.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "UIKit/UIKit.h"
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSInteger, FLEXNetworkTransactionState) {
     FLEXNetworkTransactionStateUnstarted,

--- a/Classes/ObjectExplorers/Controllers/FLEXArrayExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXArrayExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXArrayExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXBundleExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXBundleExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXBundleExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXClassExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXClassExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXClassExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXColorExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXColorExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXColorExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXDefaultsExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXDefaultsExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXDefaultsExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXDictionaryExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXDictionaryExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXDictionaryExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXImageExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXImageExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXImageExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXLayerExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXLayerExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 f. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXLayerExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXObjectExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXObjectExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
+#import <FLEX/FLEXTableViewController.h>
 
 typedef NS_ENUM(NSUInteger, FLEXObjectExplorerSection) {
     FLEXObjectExplorerSectionDescription,

--- a/Classes/ObjectExplorers/Controllers/FLEXSetExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXSetExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXSetExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXViewControllerExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXViewControllerExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXViewControllerExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/Controllers/FLEXViewExplorerViewController.h
+++ b/Classes/ObjectExplorers/Controllers/FLEXViewExplorerViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXObjectExplorerViewController.h"
+#import <FLEX/FLEXObjectExplorerViewController.h>
 
 @interface FLEXViewExplorerViewController : FLEXObjectExplorerViewController
 

--- a/Classes/ObjectExplorers/FLEXObjectExplorerFactory.h
+++ b/Classes/ObjectExplorers/FLEXObjectExplorerFactory.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXGlobalsEntry.h"
+#import <FLEX/FLEXGlobalsEntry.h>
 
 @class FLEXObjectExplorerViewController;
 

--- a/Classes/ObjectExplorers/Views/FLEXMultilineTableViewCell.h
+++ b/Classes/ObjectExplorers/Views/FLEXMultilineTableViewCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 f. All rights reserved.
 //
 
-#import "FLEXTableViewCell.h"
+#import <FLEX/FLEXTableViewCell.h>
 
 extern NSString *const kFLEXMultilineTableViewCellIdentifier;
 

--- a/Classes/ObjectExplorers/Views/FLEXTableView.m
+++ b/Classes/ObjectExplorers/Views/FLEXTableView.m
@@ -18,10 +18,13 @@
 
 - (CGFloat)_heightForHeaderInSection:(NSInteger)section {
     CGFloat height = [super _heightForHeaderInSection:section];
-    if (section == 0 && self.tableHeaderView && !@available(iOS 13.0, *)) {
+    if(@available(iOS 13.0, *)) {
+      return height;
+    }
+      
+    if (section == 0 && self.tableHeaderView) {
         return height - self.tableHeaderView.frame.size.height + 8;
     }
-
     return height;
 }
 

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -11,7 +11,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
-#import "FLEXAlert.h"
+#import <FLEX/FLEXAlert.h>
 
 #define FLEXFloor(x) (floor(UIScreen.mainScreen.scale * (x)) / UIScreen.mainScreen.scale)
 

--- a/Classes/ViewHierarchy/FLEXHierarchyTableViewController.h
+++ b/Classes/ViewHierarchy/FLEXHierarchyTableViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Flipboard. All rights reserved.
 //
 
-#import "FLEXTableViewController.h"
+#import <FLEX/FLEXTableViewController.h>
 
 @protocol FLEXHierarchyTableViewControllerDelegate;
 


### PR DESCRIPTION
This commit fixes one @available compilation issue and then makes all headers use <FLEX/*.h> syntax.

this PR redos https://github.com/Flipboard/FLEX/pull/354 and unifies other headers