### PR TITLE
Fix for color circle padding

### DIFF
--- a/Classes/ViewHierarchy/FLEXHierarchyTableViewCell.m
+++ b/Classes/ViewHierarchy/FLEXHierarchyTableViewCell.m
@@ -35,7 +35,7 @@
         self.colorCircleImageView = [[UIImageView alloc] initWithImage:defaultCircleImage];
         [self.contentView addSubview:self.colorCircleImageView];
         
-        self.textLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:14.0];
+        self.textLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightMedium];
         self.detailTextLabel.font = [FLEXUtility defaultTableViewCellLabelFont];
         self.accessoryType = UITableViewCellAccessoryDetailButton;
         

--- a/Classes/ViewHierarchy/FLEXHierarchyTableViewCell.m
+++ b/Classes/ViewHierarchy/FLEXHierarchyTableViewCell.m
@@ -75,7 +75,7 @@
 {
     [super layoutSubviews];
     
-    const CGFloat kContentPadding = 10.0;
+    const CGFloat kContentPadding = 12.0;
     const CGFloat kDepthIndicatorWidthMultiplier = 4.0;
     const CGFloat kViewBackgroundColourDimension = 20;
     
@@ -102,7 +102,7 @@
     CGRect viewBackgroundColourViewFrame = self.textLabel.frame;
     viewBackgroundColourViewFrame.size.width = kViewBackgroundColourDimension;
     viewBackgroundColourViewFrame.size.height = kViewBackgroundColourDimension;
-    viewBackgroundColourViewFrame.origin.x = CGRectGetMaxX(self.textLabel.frame) + kContentPadding;
+    viewBackgroundColourViewFrame.origin.x = CGRectGetMaxX(self.textLabel.frame) + kContentPadding / 2;
     viewBackgroundColourViewFrame.origin.y = ABS(CGRectGetHeight(self.contentView.frame) -  CGRectGetHeight(viewBackgroundColourViewFrame)) / 2;
     
     self.viewBackgroundColorView.frame = viewBackgroundColourViewFrame;


### PR DESCRIPTION
There is currently almost no padding between the view backgroundColor preview circle and the info button. To fix this I've shifted the color preview over to the left by half the kContentPadding.