### PR TITLE
Fix crashes when previewing NSData keychain items.

### DIFF
--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
@@ -83,8 +83,9 @@
     }
 
     if ([object isKindOfClass:[NSData class]]) {
-        return [NSString stringWithFormat: @"[NSData] %@", [[NSString alloc] initWithData:object
-                                                                                 encoding:NSUTF8StringEncoding]];
+        return [NSString stringWithFormat:@"[NSData] %@",
+            [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding]
+        ];
     }
 
     return [NSString stringWithFormat:@"[%@]\n\n%@", NSStringFromClass([object class]), [object description]];

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
@@ -83,10 +83,11 @@
     }
 
     if ([object isKindOfClass:[NSData class]]) {
-        return [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
+        return [NSString stringWithFormat: @"[NSData] %@", [[NSString alloc] initWithData:object
+                                                                                 encoding:NSUTF8StringEncoding]];
     }
 
-    return [NSString stringWithFormat: @"[%@]\n\n%@", NSStringFromClass([object class]), [object description]];
+    return [NSString stringWithFormat:@"[%@]\n\n%@", NSStringFromClass([object class]), [object description]];
 }
 
 

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainTableViewController.m
@@ -77,6 +77,18 @@
     }
 }
 
+- (NSString *)stringFromObject:(id)object {
+    if ([object isKindOfClass:[NSString class]]) {
+        return object;
+    }
+
+    if ([object isKindOfClass:[NSData class]]) {
+        return [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
+    }
+
+    return [NSString stringWithFormat: @"[%@]\n\n%@", NSStringFromClass([object class]), [object description]];
+}
+
 
 #pragma mark Buttons
 
@@ -154,16 +166,9 @@
     
     NSDictionary *item = self.keychainItems[indexPath.row];
     id account = item[kFLEXKeychainAccountKey];
-    if ([account isKindOfClass:[NSString class]]) {
-        cell.textLabel.text = account;
-    } else {
-        cell.textLabel.text = [NSString stringWithFormat:
-            @"[%@]\n\n%@",
-            NSStringFromClass([account class]),
-            [account description]
-        ];
-    }
-    
+
+    cell.textLabel.text = [self stringFromObject:account];
+
     return cell;
 }
 
@@ -187,12 +192,12 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     FLEXKeychainQuery *query = [self queryForItemAtIndex:indexPath.row];
-    
+
     [FLEXAlert makeAlert:^(FLEXAlert *make) {
         make.title(query.service);
-        make.message(@"Service: ").message(query.service);
-        make.message(@"\nAccount: ").message(query.account);
-        make.message(@"\nPassword: ").message(query.password);
+        make.message(@"Service: ").message([self stringFromObject:query.service]);
+        make.message(@"\nAccount: ").message([self stringFromObject:query.account]);
+        make.message(@"\nPassword: ").message([self stringFromObject:query.password]);
 
         make.button(@"Copy Service").handler(^(NSArray<NSString *> *strings) {
             [UIPasteboard.generalPasteboard flex_copy:query.service];


### PR DESCRIPTION
:wave: 

This improves upon https://github.com/Flipboard/FLEX/pull/360, by also letting you view details of keychain items that have either `service`/`account` or `password` set to `NSData` types, incorrectly. 

One frequent cause of this, is integrating the Firebase framework (c.f https://github.com/firebase/firebase-ios-sdk/issues/4742), which creates a keychain entry with a `_pfo` keychain entry, but using an `NSData` object, instead of a `NSString`. 

This lets you view such items: 
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-24 at 15 12 01](https://user-images.githubusercontent.com/1594081/73075292-e3ceaa80-3ebb-11ea-8486-2e28c5a097b9.png)

Feel free to reformat/rename anything in the PR — and thanks for all the hard work on FLEX before :)