### PR TITLE
Call super in viewWillTransitionToSize:withTransitionCoordinator:

### DIFF
--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -167,6 +167,8 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         for (UIView *outlineView in self.outlineViewsForVisibleViews.allValues) {
             outlineView.hidden = YES;


### PR DESCRIPTION
Per Apple's documentation (https://developer.apple.com/documentation/uikit/uicontentcontainer/1621466-viewwilltransitiontosize) if you override this method in your custom view controller, always call super at some point in your implementation so that UIKit can forward the size change message appropriately.

This commit adds the call to super as required.