### PR TITLE
Fix MEMORY_LEAK

### DIFF
--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -167,6 +167,8 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         for (UIView *outlineView in self.outlineViewsForVisibleViews.allValues) {
             outlineView.hidden = YES;

--- a/Classes/GlobalStateExplorers/FLEXLiveObjectsTableViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXLiveObjectsTableViewController.m
@@ -90,6 +90,7 @@ static const NSInteger kFLEXLiveObjectsSortBySizeIndex = 2;
         }
         [mutableSizesForClassNames setObject:@(class_getInstanceSize(class)) forKey:className];
     }
+    CFRelease(mutableCountsForClasses);
     free(classes);
     
     self.instanceCountsForClassNames = mutableCountsForClassNames;


### PR DESCRIPTION
Classes/GlobalStateExplorers/FLEXLiveObjectsTableViewController.m:94: error: MEMORY_LEAK
  memory dynamically allocated by call to `CFDictionaryCreateMutable()` at line 69, column 54 is not reachable after line 94, column 10.