### PR TITLE
Make several functions static to avoid warning

### DIFF
--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -33,7 +33,7 @@ static BOOL FLEXNSLogHookWorks = NO;
 
 BOOL (*os_log_shim_enabled)(void *addr) = nil;
 BOOL (*orig_os_log_shim_enabled)(void *addr) = nil;
-BOOL my_os_log_shim_enabled(void *addr) {
+static BOOL my_os_log_shim_enabled(void *addr) {
     return NO;
 }
 
@@ -51,17 +51,17 @@ BOOL my_os_log_shim_enabled(void *addr) {
         return;
     }
 
-    FLEXDidHookNSLog = rebind_symbols((struct rebinding[1]) {
+    FLEXDidHookNSLog = rebind_symbols((struct rebinding[1]) {{
         "os_log_shim_enabled",
         (void *)my_os_log_shim_enabled,
         (void **)&orig_os_log_shim_enabled
-    }, 1) == 0;
-    
+    }}, 1) == 0;
+
     if (FLEXDidHookNSLog && orig_os_log_shim_enabled != nil) {
         // Check if our rebinding worked
         FLEXNSLogHookWorks = my_os_log_shim_enabled(addr) == NO;
     }
-    
+
     // So, just because we rebind the lazily loaded symbol for
     // this function doesn't mean it's even going to be used.
     // While it seems to be sufficient for the simulator, for
@@ -100,7 +100,7 @@ BOOL my_os_log_shim_enabled(void *addr) {
         __strong __typeof(weakSelf) self = weakSelf;
         [self handleUpdateWithNewMessages:newMessages];
     };
-    
+
     if (FLEXOSLogAvailable() && !FLEXNSLogHookWorks) {
         _logController = [FLEXOSLogController withUpdateHandler:logHandler];
     } else {
@@ -109,9 +109,9 @@ BOOL my_os_log_shim_enabled(void *addr) {
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.title = @"Loading...";
-    
+
     // Toolbar buttons //
-    
+
     UIBarButtonItem *scrollDown = [UIBarButtonItem
         itemWithImage:FLEXResources.scrollToBottomIcon
         target:self
@@ -141,7 +141,7 @@ BOOL my_os_log_shim_enabled(void *addr) {
         cellConfiguration:^(FLEXSystemLogCell *cell, FLEXSystemLogMessage *message, NSInteger row) {
             cell.logMessage = message;
             cell.highlightedText = self.filterText;
-            
+
             if (row % 2 == 0) {
                 cell.backgroundColor = FLEXColor.primaryBackgroundColor;
             } else {
@@ -152,11 +152,11 @@ BOOL my_os_log_shim_enabled(void *addr) {
             return [displayedText localizedCaseInsensitiveContainsString:filterText];
         }
     ];
-    
+
     self.logMessages.cellRegistrationMapping = @{
         kFLEXSystemLogCellIdentifier : [FLEXSystemLogCell class]
     };
-    
+
     return @[self.logMessages];
 }
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -56,12 +56,12 @@ static BOOL my_os_log_shim_enabled(void *addr) {
         (void *)my_os_log_shim_enabled,
         (void **)&orig_os_log_shim_enabled
     }}, 1) == 0;
-
+    
     if (FLEXDidHookNSLog && orig_os_log_shim_enabled != nil) {
         // Check if our rebinding worked
         FLEXNSLogHookWorks = my_os_log_shim_enabled(addr) == NO;
     }
-
+    
     // So, just because we rebind the lazily loaded symbol for
     // this function doesn't mean it's even going to be used.
     // While it seems to be sufficient for the simulator, for
@@ -100,7 +100,7 @@ static BOOL my_os_log_shim_enabled(void *addr) {
         __strong __typeof(weakSelf) self = weakSelf;
         [self handleUpdateWithNewMessages:newMessages];
     };
-
+    
     if (FLEXOSLogAvailable() && !FLEXNSLogHookWorks) {
         _logController = [FLEXOSLogController withUpdateHandler:logHandler];
     } else {
@@ -109,9 +109,9 @@ static BOOL my_os_log_shim_enabled(void *addr) {
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.title = @"Loading...";
-
+    
     // Toolbar buttons //
-
+    
     UIBarButtonItem *scrollDown = [UIBarButtonItem
         itemWithImage:FLEXResources.scrollToBottomIcon
         target:self
@@ -141,7 +141,7 @@ static BOOL my_os_log_shim_enabled(void *addr) {
         cellConfiguration:^(FLEXSystemLogCell *cell, FLEXSystemLogMessage *message, NSInteger row) {
             cell.logMessage = message;
             cell.highlightedText = self.filterText;
-
+    
             if (row % 2 == 0) {
                 cell.backgroundColor = FLEXColor.primaryBackgroundColor;
             } else {
@@ -152,11 +152,11 @@ static BOOL my_os_log_shim_enabled(void *addr) {
             return [displayedText localizedCaseInsensitiveContainsString:filterText];
         }
     ];
-
+    
     self.logMessages.cellRegistrationMapping = @{
         kFLEXSystemLogCellIdentifier : [FLEXSystemLogCell class]
     };
-
+    
     return @[self.logMessages];
 }
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -141,7 +141,7 @@ static BOOL my_os_log_shim_enabled(void *addr) {
         cellConfiguration:^(FLEXSystemLogCell *cell, FLEXSystemLogMessage *message, NSInteger row) {
             cell.logMessage = message;
             cell.highlightedText = self.filterText;
-    
+            
             if (row % 2 == 0) {
                 cell.backgroundColor = FLEXColor.primaryBackgroundColor;
             } else {

--- a/Classes/Utility/Runtime/Objc/FLEXRuntimeSafety.m
+++ b/Classes/Utility/Runtime/Objc/FLEXRuntimeSafety.m
@@ -19,7 +19,7 @@ CFSetRef FLEXKnownUnsafeIvars = nil;
     (class_getInstanceVariable([cls class], name) ?: (void *)kCFNull)
 
 __attribute__((constructor))
-void FLEXRuntimeSafteyInit() {
+static void FLEXRuntimeSafteyInit() {
     FLEXKnownUnsafeClasses = CFSetCreate(
         kCFAllocatorDefault,
         (const void **)(uintptr_t)FLEXKnownUnsafeClassList(),


### PR DESCRIPTION
Several functions are not marked as static and it will report missing prototypes warning and failed to build if `-Wmissing-prototypes` flag is on.

Also fixed an issue with `-Wmissing-braces` flag on.