### PR TITLE
Dispatch JSON response registration to main queue in FLEXManager+Networking

### DIFF
--- a/Classes/Manager/FLEXManager+Networking.m
+++ b/Classes/Manager/FLEXManager+Networking.m
@@ -15,17 +15,18 @@
 @implementation FLEXManager (Networking)
 
 + (void)load {
-    // Register array/dictionary viewer for JSON responses
-    [self.sharedManager setCustomViewerForContentType:@"application/json"
-        viewControllerFutureBlock:^UIViewController *(NSData *data) {
-            id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-            if (jsonObject) {
-                return [FLEXObjectExplorerFactory explorerViewControllerForObject:jsonObject];
+    dispatch_asnyc(dispatch_get_main_queue(), ^{
+        // Register array/dictionary viewer for JSON responses
+        [self.sharedManager setCustomViewerForContentType:@"application/json"
+            viewControllerFutureBlock:^UIViewController *(NSData *data) {
+                id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+                if (jsonObject) {
+                    return [FLEXObjectExplorerFactory explorerViewControllerForObject:jsonObject];
+                }
+                return nil;
             }
-        
-            return nil;
-        }
-    ];
+        ];
+    });
 }
 
 - (BOOL)isNetworkDebuggingEnabled {


### PR DESCRIPTION
Dispatch JSON response registration to main queue in `FLEXManager+Networking`

Issue introduced in 740daab55b42dfc7afeb5adc936fc36bc91f0ff8

The `load` call can happen in any thread but the `setCustomViewerForContentType` only works on main thread.