### PR TITLE
Update README to use the current Swift `.shared`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Short version:
 
 ```swift
 // Swift
-FLEXManager.shared().showExplorer()
+FLEXManager.shared.showExplorer()
 ```
 
 More complete version:


### PR DESCRIPTION
It seems this has been changed from version 3.0 to 4.0, and you now access the singleton in Swift with `.shared` rather than `.shared()`. This reflects that change.