### PR TITLE
use __typeof instead of typeof to compile for Cxx instead of GNUxx

### DIFF
--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserController.m
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserController.m
@@ -321,7 +321,7 @@
 #if FLEX_AT_LEAST_IOS13_SDK
 
 - (UIContextMenuConfiguration *)tableView:(UITableView *)tableView contextMenuConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath point:(CGPoint)point __IOS_AVAILABLE(13.0) {
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     return [UIContextMenuConfiguration configurationWithIdentifier:nil
                                                    previewProvider:nil
                                                     actionProvider:^UIMenu * _Nullable(NSArray<UIMenuElement *> * _Nonnull suggestedActions) {


### PR DESCRIPTION
I have problem when compiling this, and I think others may also have.
> Use __typeof instead of typeof. This is because both __typeof and typeof are extensions to C, but typeof is only enabled in Clang when the language is a GNUXX variant of C, but not for CXX.

https://stackoverflow.com/questions/32145326/weak-typeofself-weakself-self-expected-at-end-of-declaration/32145709#32145709