### PR TITLE
Remove retain cycles from selectionHandler in several files

### DIFF
--- a/Classes/ObjectExplorers/Sections/FLEXMutableListSection.m
+++ b/Classes/ObjectExplorers/Sections/FLEXMutableListSection.m
@@ -29,12 +29,12 @@ configurationBlock:(FLEXMutableListCellForElement)cellConfig
     self = [super init];
     if (self) {
         _configureCell = cellConfig;
-        
+
         self.list = list.mutableCopy;
         self.customFilter = filterBlock;
         self.hideSectionTitle = YES;
     }
-    
+
     return self;
 }
 
@@ -48,7 +48,7 @@ configurationBlock:(FLEXMutableListCellForElement)cellConfig
 - (void)setList:(NSMutableArray *)list {
     NSParameterAssert(list);
     _collection = list;
-    
+
     [self reloadData];
 }
 
@@ -79,11 +79,15 @@ configurationBlock:(FLEXMutableListCellForElement)cellConfig
 
 - (void (^)(__kindof UIViewController *))didSelectRowAction:(NSInteger)row {
     if (self.selectionHandler) {
+        __weak __typeof(self) weakSelf = self;
         return ^(UIViewController *host) {
-            self.selectionHandler(host, self.filteredList[row]);
+            __strong __typeof(self) strongSelf = weakSelf;
+            if (strongSelf) {
+                strongSelf.selectionHandler(host, strongSelf.filteredList[row]);
+            }
         };
     }
-    
+
     return nil;
 }
 
@@ -95,7 +99,7 @@ configurationBlock:(FLEXMutableListCellForElement)cellConfig
     if (self.cellRegistrationMapping.count) {
         return self.cellRegistrationMapping.allKeys.firstObject;
     }
-    
+
     return [super reuseIdentifierForRow:row];
 }
 

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXBundleShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXBundleShortcuts.m
@@ -18,6 +18,7 @@
 #pragma mark Overrides
 
 + (instancetype)forObject:(NSBundle *)bundle {
+    __weak __typeof(self) weakSelf = self;
     return [self forObject:bundle additionalRows:@[
         [FLEXActionShortcut
             title:@"Browse Bundle Directory" subtitle:nil
@@ -30,7 +31,10 @@
         ],
         [FLEXActionShortcut title:@"Browse Bundle as Database…" subtitle:nil
             selectionHandler:^(UIViewController *host, NSBundle *bundle) {
-                [self promptToExportBundleAsDatabase:bundle host:host];
+                __strong __typeof(self) strongSelf = weakSelf;
+                if (strongSelf) {
+                    [strongSelf promptToExportBundleAsDatabase:bundle host:host];
+                }
             }
             accessoryType:^UITableViewCellAccessoryType(NSBundle *bundle) {
                 return UITableViewCellAccessoryDisclosureIndicator;
@@ -62,22 +66,22 @@
 
 + (void)browseBundleAsDatabase:(NSBundle *)bundle host:(UIViewController *)host name:(NSString *)name {
     NSParameterAssert(name.length);
-    
+
     UIAlertController *progress = [FLEXAlert makeAlert:^(FLEXAlert *make) {
         make.title(@"Generating Database");
         // Some iOS version glitch out of there is
         // no initial message and you add one later
         make.message(@"…");
     }];
-    
+
     [host presentViewController:progress animated:YES completion:^{
         // Generate path to store db
         NSString *path = [NSSearchPathForDirectoriesInDomains(
             NSLibraryDirectory, NSUserDomainMask, YES
         )[0] stringByAppendingPathComponent:name];
-        
+
         progress.message = [path stringByAppendingString:@"\n\nCreating database…"];
-        
+
         // Generate db and show progress
         [FLEXRuntimeExporter createRuntimeDatabaseAtPath:path
             forImages:@[bundle.executablePath]


### PR DESCRIPTION
Remove retain cycles from `selectionHandler` in several files.

These self were retained by the blocks `selectionHandler`, so we should use `weakSelf` and `strongSelf` instead.