### PR TITLE
Remove redundant FLEXPointerIsTaggedPointer function

### DIFF
--- a/Classes/Utility/Runtime/Objc/FLEXObjcInternal.h
+++ b/Classes/Utility/Runtime/Objc/FLEXObjcInternal.h
@@ -57,7 +57,7 @@ NS_INLINE BOOL flex_isTaggedPointer(const void *ptr)  {
     #endif
 }
 
-#define FLEXIsTaggedPointer(obj) flex_isTaggedPointer((__bridge void *)obj)
+#define FLEXPointerIsTaggedPointer(obj) flex_isTaggedPointer((__bridge void *)obj)
 
 BOOL FLEXPointerIsReadable(const void * ptr);
 

--- a/Classes/Utility/Runtime/Objc/FLEXObjcInternal.mm
+++ b/Classes/Utility/Runtime/Objc/FLEXObjcInternal.mm
@@ -7,16 +7,16 @@
 
 /*
  * Copyright (c) 2005-2007 Apple Inc.  All Rights Reserved.
- * 
+ *
  * @APPLE_LICENSE_HEADER_START@
- * 
+ *
  * This file contains Original Code and/or Modifications of Original Code
  * as defined in and that are subject to the Apple Public Source License
  * Version 2.0 (the 'License'). You may not use this file except in
  * compliance with the License. Please obtain a copy of the License at
  * http://www.opensource.apple.com/apsl/ and read it before using this
  * file.
- * 
+ *
  * The Original Code and all software distributed under the License are
  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -24,7 +24,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
  * Please see the License for the specific language governing rights and
  * limitations under the License.
- * 
+ *
  * @APPLE_LICENSE_HEADER_END@
  */
 
@@ -74,10 +74,6 @@ NS_INLINE BOOL flex_isExtTaggedPointer(const void *ptr)  {
 /////////////////////////////////////
 
 extern "C" {
-
-BOOL FLEXPointerIsTaggedPointer(const void *pointer) {
-    return flex_isTaggedPointer(pointer);
-}
 
 BOOL FLEXPointerIsReadable(const void *inPtr) {
     kern_return_t error = KERN_SUCCESS;
@@ -184,5 +180,5 @@ BOOL FLEXPointerIsValidObjcObject(const void *ptr) {
     return NO;
 }
 
-    
+
 } // End extern "C"

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
@@ -43,13 +43,13 @@
 
 - (id)initWithIvar:(Ivar)ivar {
     NSParameterAssert(ivar);
-    
+
     self = [super init];
     if (self) {
         _objc_ivar = ivar;
         [self examine];
     }
-    
+
     return self;
 }
 
@@ -73,7 +73,7 @@
     _name         = @(ivar_getName(self.objc_ivar) ?: "(nil)");
     _offset       = ivar_getOffset(self.objc_ivar);
     _typeEncoding = @(ivar_getTypeEncoding(self.objc_ivar) ?: "");
-    
+
     NSString *typeForDetails = _typeEncoding;
     NSString *sizeForDetails = nil;
     if (_typeEncoding.length) {
@@ -85,7 +85,7 @@
         typeForDetails = @"no type info";
         sizeForDetails = @"unknown size";
     }
-    
+
     Dl_info exeInfo;
     if (dladdr(_objc_ivar, &exeInfo)) {
         _imagePath = exeInfo.dli_fname ? @(exeInfo.dli_fname) : nil;
@@ -101,7 +101,7 @@
     id value = nil;
     if (!FLEXIvarIsSafe(_objc_ivar) ||
         _type == FLEXTypeEncodingNull ||
-        FLEXIsTaggedPointer(target)) {
+        FLEXPointerIsTaggedPointer(target)) {
         return nil;
     }
 
@@ -155,7 +155,7 @@
     if (type.flex_typeIsNonObjcPointer && type.flex_pointeeType != FLEXTypeEncodingVoid) {
         return [self getValue:target];
     }
-    
+
     return [FLEXRuntimeUtility
         potentiallyUnwrapBoxedPointer:[self getValue:target]
         type:type.UTF8String


### PR DESCRIPTION
Remove redundant `FLEXPointerIsTaggedPointer` function.

This caused build failure on my local checkout, the reason is that the function `FLEXPointerIsTaggedPointer` doesn't have a definition.
Since we already have the macro, we don't need this function. I just did a rename of the macro instead.

This was added in https://github.com/Flipboard/FLEX/commit/5d919eb3290762cf37f43a7eca729307e3bcfad2