### PR TITLE
 Add copy action for database browser row selection alert

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -113,7 +113,11 @@
     
     [FLEXAlert makeAlert:^(FLEXAlert *make) {
         make.title([@"Row " stringByAppendingString:@(row).stringValue]);
-        make.message([fields componentsJoinedByString:@"\n\n"]);
+        NSString *message = [fields componentsJoinedByString:@"\n\n"];
+        make.message(message);
+        make.button(@"Copy").handler(^(NSArray<NSString *> *strings) {
+            UIPasteboard.generalPasteboard.string = message;
+        });
         make.button(@"Dismiss").cancelStyle();
     } showFrom:self];
 }


### PR DESCRIPTION
With FLEX 4.0, there is no ability to copy the db values from the DB browser. Before we improve this experience, let's add a quick copy action for now.

Demo:
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-07 at 23 42 31](https://user-images.githubusercontent.com/627231/87093646-6214d400-c1f2-11ea-8436-e839d7e419be.png)
