### PR TITLE
Move custom additions to the top

### DIFF
--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.h
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2020 Flipboard. All rights reserved.
 //
 
-#import <FLEX/FLEXFilteringTableViewController.h>
+#import "FLEXFilteringTableViewController.h"
 @protocol FLEXGlobalsTableViewControllerDelegate;
 
 typedef NS_ENUM(NSUInteger, FLEXGlobalsSectionKind) {

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.h
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.h
@@ -6,10 +6,11 @@
 //  Copyright (c) 2020 Flipboard. All rights reserved.
 //
 
-#import "FLEXFilteringTableViewController.h"
+#import <FLEX/FLEXFilteringTableViewController.h>
 @protocol FLEXGlobalsTableViewControllerDelegate;
 
 typedef NS_ENUM(NSUInteger, FLEXGlobalsSectionKind) {
+    FLEXGlobalsSectionCustom,
     /// NSProcessInfo, Network history, system log,
     /// heap, address explorer, libraries, app classes
     FLEXGlobalsSectionProcessAndEvents,
@@ -19,7 +20,6 @@ typedef NS_ENUM(NSUInteger, FLEXGlobalsSectionKind) {
     FLEXGlobalsSectionAppShortcuts,
     /// UIPasteBoard.general, UIScreen, UIDevice
     FLEXGlobalsSectionMisc,
-    FLEXGlobalsSectionCustom,
     FLEXGlobalsSectionCount
 };
 


### PR DESCRIPTION
I find myself using the custom additions much more frequent than built actions. I believe this is true to a lot of others as well. So this PR tries to move them to the top so they are more accessible.