### PR TITLE
Add better debugging message for FLEXProperty and FLEXIvar

### DIFF
--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
@@ -37,7 +37,8 @@
 }
 
 + (instancetype)named:(NSString *)name onClass:(Class)cls {
-    Ivar ivar = class_getInstanceVariable(cls, name.UTF8String);
+    Ivar _Nullable ivar = class_getInstanceVariable(cls, name.UTF8String);
+    NSAssert(ivar, @"Cannot find ivar with name %@ on class %@", name, cls);
     return [self ivar:ivar];
 }
 

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXProperty.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXProperty.m
@@ -45,8 +45,9 @@
 }
 
 + (instancetype)named:(NSString *)name onClass:(Class)cls {
-    NSParameterAssert(class_getProperty(cls, name.UTF8String));
-    return [self property:class_getProperty(cls, name.UTF8String) onClass:cls];
+    objc_property_t _Nullable property = class_getProperty(cls, name.UTF8String);
+    NSAssert(property, @"Cannot find property with name %@ on class %@", name, cls);
+    return [self property:property onClass:cls];
 }
 
 + (instancetype)propertyWithName:(NSString *)name attributes:(FLEXPropertyAttributes *)attributes {
@@ -55,34 +56,34 @@
 
 - (id)initWithProperty:(objc_property_t)property onClass:(Class)cls {
     NSParameterAssert(property);
-    
+
     self = [super init];
     if (self) {
         _objc_property = property;
         _attributes    = [FLEXPropertyAttributes attributesForProperty:property];
         _name          = @(property_getName(property) ?: "(nil)");
         _cls           = cls;
-        
+
         if (!_attributes) [NSException raise:NSInternalInconsistencyException format:@"Error retrieving property attributes"];
         if (!_name) [NSException raise:NSInternalInconsistencyException format:@"Error retrieving property name"];
-        
+
         [self examine];
     }
-    
+
     return self;
 }
 
 - (id)initWithName:(NSString *)name attributes:(FLEXPropertyAttributes *)attributes {
     NSParameterAssert(name); NSParameterAssert(attributes);
-    
+
     self = [super init];
     if (self) {
         _attributes    = attributes;
         _name          = name;
-        
+
         [self examine];
     }
-    
+
     return self;
 }
 
@@ -160,7 +161,7 @@
     if (dladdr(_objc_property, &exeInfo)) {
         _imagePath = exeInfo.dli_fname ? @(exeInfo.dli_fname) : nil;
     }
-    
+
     if ((!_multiple || !_uniqueCheckFlag) && _cls) {
         _multiple = _objc_property != class_getProperty(_cls, self.name.UTF8String);
 
@@ -214,7 +215,7 @@
     } else {
         [attributesStrings addObject:@"readwrite"];
     }
-    
+
     // Class or not
     if (self.isClassProperty) {
         [attributesStrings addObject:@"class"];
@@ -236,7 +237,7 @@
 
 - (id)getValue:(id)target {
     if (!target) return nil;
-    
+
     // We don't care about checking dynamically whether the getter
     // _now_ exists on this object. If the getter doesn't exist
     // when this property is initialized, it will never call it.


### PR DESCRIPTION
Add better debugging message for `FLEXProperty` and `FLEXIvar`.

When the assertion failed, we want to know which class and which name are the problematic combinations.