### PR TITLE
Return empty array when the rows are nil in FLEXSQLResult

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -99,24 +99,25 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
 }
 
 - (NSArray<NSString *> *)queryAllTables {
-    return [[self executeStatement:QUERY_TABLENAMES].rows flex_mapped:^id(NSArray *table, NSUInteger idx) {
+    NSArray<NSArray<NSString *> *> *rows = [self executeStatement:QUERY_TABLENAMES].rows;
+    return rows ? [rows flex_mapped:^id(NSArray *table, NSUInteger idx) {
         return table.firstObject;
-    }];
+    }] : @[];
 }
 
 - (NSArray<NSString *> *)queryAllColumnsOfTable:(NSString *)tableName {
     NSString *sql = [NSString stringWithFormat:@"PRAGMA table_info('%@')",tableName];
     FLEXSQLResult *results = [self executeStatement:sql];
-    
-    return [results.keyedRows flex_mapped:^id(NSDictionary *column, NSUInteger idx) {
+
+    return results.keyedRows ? [results.keyedRows flex_mapped:^id(NSDictionary *column, NSUInteger idx) {
         return column[@"name"];
-    }];
+    }] : @[];
 }
 
 - (NSArray<NSArray *> *)queryAllDataInTable:(NSString *)tableName {
     return [self executeStatement:[@"SELECT * FROM "
         stringByAppendingString:tableName
-    ]].rows;
+    ]].rows ?: @[];
 }
 
 - (FLEXSQLResult *)executeStatement:(NSString *)sql {


### PR DESCRIPTION
From internal crash stack trace, we are seeing:
```
Thread #0 Crashed:
0 CoreFoundation 0x18abf0300 __exceptionPreprocess + 228
1 libobjc.A.dylib 0x18a904c18 objc_exception_throw + 56
2 CoreFoundation 0x18aaed1f4 +[NSException raise:format:arguments:] + 96
3 Foundation 0x18af31994 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 128
4 NotInCore 0x10a2826fc -[FLEXMutableListSection setList:] (FLEXMutableListSection.m:49)
5 NotInCore 0x10a2825b4 -[FLEXMutableListSection initWithList:configurationBlock:filterMatcher:] (FLEXMutableListSection.m:33)
6 NotInCore 0x10a23b120 __cmp_gen_1f118 (Something else)
7 NotInCore 0x10a282c20 +[FLEXMutableListSection list:cellConfiguration:filterMatcher:] (FLEXMutableListSection.m:23)
8 NotInCore 0x10a248824 __cmp_gen_2c814 (FHSSnapshotView.m:167)
9 NotInCore 0x10a2b61d0 -[FLEXTableListViewController makeSections] (FLEXTableListViewController.m:62)
10 NotInCore 0x10a2238b8 __cmp_gen_78ac (Something else)
11 NotInCore 0x10a26cd6c -[FLEXFilteringTableViewController setFilterDelegate:] (FLEXFilteringTableViewController.m:45)
12 NotInCore 0x10a26cb8c -[FLEXFilteringTableViewController loadView] (FLEXFilteringTableViewController.m:26)
13 UIKitCore 0x18e6cb360 -[UIViewController loadViewIfRequired] + 184
14 UIKitCore 0x18e6cba48 -[UIViewController view] + 28
15 UIKitCore 0x18e6276cc -[UINavigationController _startCustomTransition:] + 1144
16 UIKitCore 0x18e63bba0 -[UINavigationController _startDeferredTransitionIfNeeded:] + 688
17 UIKitCore 0x18e63cf40 -[UINavigationController __viewWillLayoutSubviews] + 172
18 UIKitCore 0x18e61fc24 -[UILayoutContainerView layoutSubviews] + 224
19 UIKitCore 0x18f20b280 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 2164
20 QuartzCore 0x19185a714 -[CALayer layoutSublayers] + 288
21 QuartzCore 0x19185ab54 CA::Layer::layout_if_needed(CA::Transaction*) + 468
22 QuartzCore 0x19186d038 CA::Layer::layout_and_display_if_needed(CA::Transaction*) + 140
23 QuartzCore 0x1917b1958 CA::Context::commit_transaction(CA::Transaction*, double) + 300
24 QuartzCore 0x1917dc4b8 CA::Transaction::commit() + 652
25 UIKitCore 0x18ed63b58 _afterCACommitHandler + 140
26 CoreFoundation 0x18ab6aee4 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 32
27 CoreFoundation 0x18ab65b74 __CFRunLoopDoObservers + 416
28 CoreFoundation 0x18ab66014 __CFRunLoopRun + 1016
29 CoreFoundation 0x18ab658f0 CFRunLoopRunSpecific + 476
30 GraphicsServices 0x194f7c600 GSEventRunModal + 160
31 UIKitCore 0x18ed39354 UIApplicationMain + 1940
32 SomeApp 0x1004a76dc main (main.m:36)
33 libdyld.dylib 0x18a9e12d8 start + 0
```

The problem is because the `.rows` and `.keyedRows` parameters are nullable, but we are asserting in `FLEXMutableListSection` that the array is nonnull.

So return empty array should fix the crashes.