### PR TITLE
Resolve Xcode 12 linker error

### DIFF
--- a/Classes/Manager/FLEXManager+Extensibility.h
+++ b/Classes/Manager/FLEXManager+Extensibility.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
                                   action:(dispatch_block_t)action
                              description:(NSString *)description;
 
++ (void)loadExtensibility;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Manager/FLEXManager+Extensibility.m
+++ b/Classes/Manager/FLEXManager+Extensibility.m
@@ -170,7 +170,7 @@
     } description:@"Toggle file browser menu"];
 }
 
-+ (void)load {
++ (void)loadExtensibility {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.sharedManager registerDefaultSimulatorShortcuts];
     });

--- a/Classes/Manager/FLEXManager+Networking.h
+++ b/Classes/Manager/FLEXManager+Networking.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setCustomViewerForContentType:(NSString *)contentType
             viewControllerFutureBlock:(FLEXCustomContentViewerFuture)viewControllerFutureBlock;
 
++ (void)loadNetworking;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Manager/FLEXManager+Networking.m
+++ b/Classes/Manager/FLEXManager+Networking.m
@@ -15,7 +15,7 @@
 
 @implementation FLEXManager (Networking)
 
-+ (void)load {
++ (void)loadNetworking {
     if (NSUserDefaults.standardUserDefaults.flex_registerDictionaryJSONViewerOnLaunch) {
         dispatch_async(dispatch_get_main_queue(), ^{
             // Register array/dictionary viewer for JSON responses

--- a/Classes/Manager/FLEXManager.m
+++ b/Classes/Manager/FLEXManager.m
@@ -12,6 +12,9 @@
 #import "FLEXWindow.h"
 #import "FLEXObjectExplorerViewController.h"
 #import "FLEXFileBrowserController.h"
+#import "FLEXManager+Extensibility.h"
+#import "FLEXManager+Networking.h"
+
 
 @interface FLEXManager () <FLEXWindowEventDelegate, FLEXExplorerViewControllerDelegate>
 
@@ -43,6 +46,11 @@
         _customContentTypeViewers = [NSMutableDictionary new];
     }
     return self;
+}
+
++ (void)load {
+    [self loadExtensibility];
+    [self loadNetworking];
 }
 
 - (FLEXWindow *)explorerWindow {


### PR DESCRIPTION
Address [Xcode 12 linker error](https://github.com/Flipboard/FLEX/issues/434), where `+load` method in two categories causing conflicts.
