### PR TITLE
Remove NSParameterAssert check in closeTab method

### DIFF
--- a/Classes/ExplorerInterface/Tabs/FLEXTabList.m
+++ b/Classes/ExplorerInterface/Tabs/FLEXTabList.m
@@ -80,10 +80,10 @@
 
 - (void)closeTab:(UINavigationController *)tab {
     NSParameterAssert(tab);
-    NSParameterAssert([self.openTabs containsObject:tab]);
     NSInteger idx = [self.openTabs indexOfObject:tab];
-    
-    [self closeTabAtIndex:idx];
+    if (idx != NSNotFound) {
+        [self closeTabAtIndex:idx];
+    }
 }
 
 - (void)closeTabAtIndex:(NSInteger)idx {


### PR DESCRIPTION
`NSParameterAssert` is a bit of aggressive. From our logs there are weird calling sequences that triggers `closeTab` multiple times, thus cause the same tab being closed several times and cause crashes.

We don't really need to be that strict here since close a non existent tab does no harm, so let's just change it to be slightly safer.