### PR TITLE
Remove assert that blocks Realm

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -53,11 +53,6 @@
                          rowIDs:(nullable NSArray<NSString *> *)rowIDs
                       tableName:(nullable NSString *)tableName
                        database:(nullable id<FLEXDatabaseManager>)databaseManager {
-    // Must supply all optional parameters as one, or none
-    BOOL all = rowIDs && tableName && databaseManager;
-    BOOL none = !rowIDs && !tableName && !databaseManager;
-    NSParameterAssert(all || none);
-
     self = [super init];
     if (self) {
         self->_columns = columnNames.copy;


### PR DESCRIPTION
Proposed fix to #621. A realm database table opens as expected when this `NSParameterAssert` is removed.