### PR TITLE
Add option to ignore specific first responder classes for keyboard shortcuts

### DIFF
--- a/Classes/Manager/FLEXManager+Extensibility.h
+++ b/Classes/Manager/FLEXManager+Extensibility.h
@@ -78,6 +78,11 @@ NS_ASSUME_NONNULL_BEGIN
                                   action:(dispatch_block_t)action
                              description:(NSString *)description;
 
+/// The simulator shortcuts will no-op if there is already a first responder in the window.
+/// Sometimes we might want to still allow simulator shortcuts despite this.
+/// @param ignoredClassNames Classes that should be ignored by the simulator shortcut manager.
+- (void)setSimulatorShortcutIgnoredClassNames:(NSArray<NSString *> *)ignoredClassNames;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Manager/FLEXManager+Extensibility.m
+++ b/Classes/Manager/FLEXManager+Extensibility.m
@@ -105,6 +105,11 @@
 #endif
 }
 
+- (void)setSimulatorShortcutIgnoredClassNames:(NSArray<NSString *> *)ignoredClassNames {
+#if TARGET_OS_SIMULATOR
+    [FLEXKeyboardShortcutManager.sharedManager setSimulatorShortcutIgnoredClassNames:ignoredClassNames];
+#endif
+}
 
 #pragma mark - Shortcuts Defaults
 

--- a/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.h
+++ b/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.h
@@ -23,6 +23,9 @@
                              description:(NSString *)description
                            allowOverride:(BOOL)allowOverride;
 
+/// @param ignoredClassNames Classes that should be ignored by the simulator shortcut manager.
+- (void)setSimulatorShortcutIgnoredClassNames:(NSArray<NSString *> *)ignoredClassNames;
+
 @property (nonatomic, getter=isEnabled) BOOL enabled;
 @property (nonatomic, readonly) NSString *keyboardShortcutsDescription;
 

--- a/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.m
+++ b/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.m
@@ -119,7 +119,9 @@
 
 @end
 
-@implementation FLEXKeyboardShortcutManager
+@implementation FLEXKeyboardShortcutManager {
+    NSArray<NSString *> *_ignoredFirstResponderClassNames;
+}
 
 + (instancetype)sharedManager {
     static FLEXKeyboardShortcutManager *sharedManager = nil;
@@ -222,6 +224,10 @@
     }
 }
 
+- (void)setSimulatorShortcutIgnoredClassNames:(NSArray<NSString *> *)ignoredClassNames {
+    _ignoredFirstResponderClassNames = ignoredClassNames;
+}
+
 static const long kFLEXControlKeyCode = 0xe0;
 static const long kFLEXShiftKeyCode = 0xe1;
 static const long kFLEXCommandKeyCode = 0xe3;
@@ -257,8 +263,9 @@ static const long kFLEXCommandKeyCode = 0xe3;
     if (isKeyDown && modifiedInput.length > 0 && interactionEnabled) {
         UIResponder *firstResponder = nil;
         for (UIWindow *window in FLEXUtility.allWindows) {
-            firstResponder = [window valueForKey:@"firstResponder"];
-            if (firstResponder) {
+            NSString *const className = NSStringFromClass([firstResponder class]);
+            const BOOL isIgnored = [_ignoredFirstResponderClassNames containsObject:className];
+            if (firstResponder && !isIgnored) {
                 hasFirstResponder = YES;
                 break;
             }


### PR DESCRIPTION
There are instances where a view will be first responder, but we still want to allow keyboard shortcuts.

This change adds an ignore-list for allowing FLEX keyboard shortcuts even if there is a first responder on the given classes.