### PR TITLE
chore: adds network history accessibility ids

### DIFF
--- a/Classes/GlobalStateExplorers/FLEXWebViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXWebViewController.m
@@ -78,6 +78,28 @@
     self.webView.frame = self.view.bounds;
     self.webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
+    // Set accessibility identifiers for automated testing
+    if ([self.title containsString:@"Request"]) {
+        self.webView.accessibilityIdentifier = @"network_request_body";
+        self.webView.accessibilityLabel = @"Request Body";
+        if (self.originalText.length > 0) {
+            self.webView.accessibilityValue = self.originalText;
+        }
+    } else if ([self.title containsString:@"Response"]) {
+        self.webView.accessibilityIdentifier = @"network_response_body";
+        self.webView.accessibilityLabel = @"Response Body";
+        if (self.originalText.length > 0) {
+            self.webView.accessibilityValue = self.originalText;
+        }
+    } else {
+        // Generic body content
+        self.webView.accessibilityIdentifier = @"network_body_content";
+        self.webView.accessibilityLabel = @"Network Body Content";
+        if (self.originalText.length > 0) {
+            self.webView.accessibilityValue = self.originalText;
+        }
+    }
+
     if (self.originalText.length > 0) {
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
             initWithTitle:@"Copy" style:UIBarButtonItemStylePlain target:self action:@selector(copyButtonTapped:)

--- a/Classes/Network/FLEXNetworkMITMViewController.m
+++ b/Classes/Network/FLEXNetworkMITMViewController.m
@@ -491,6 +491,9 @@ typedef NS_ENUM(NSInteger, FLEXNetworkObserverMode) {
         cell.backgroundColor = FLEXColor.primaryBackgroundColor;
     }
 
+    // Add accessibility identifier for automated testing
+    cell.accessibilityIdentifier = [NSString stringWithFormat:@"network_call_%ld", (long)indexPath.row];
+
     return cell;
 }
 


### PR DESCRIPTION
# 🎯 Add Accessibility Identifiers for Network History Automation Testing

## Why (Problem/Motivation)
- **Test Automation Support**: Enable automated API validation testing by providing unique, programmatic access to network history UI elements
- **Accessibility Gap**: Network call list items and request/response body views lacked proper accessibility identifiers for automation scripts
- **Developer Productivity**: Improve debugging workflow efficiency by making network inspection programmatically accessible

## What (Changes Made)
- ✅ Added unique accessibility identifiers to network call table cells (`network_call_{index}`)
- ✅ Added accessibility identifiers for request/response body web views (`network_request_body`, `network_response_body`)
- ✅ Implemented proper accessibility labels and values for better semantic meaning
- ✅ Ensured fallback identifier for generic network body content (`network_body_content`)

## How (Implementation Details)

### Network Call List Items
**File**: `Classes/Network/FLEXNetworkMITMViewController.m`
- Modified `tableView:cellForRowAtIndexPath:` to assign unique identifiers
- Pattern: `network_call_0`, `network_call_1`, etc.
- Uses row index for guaranteed uniqueness within the visible list

### Request/Response Body Views
**File**: `Classes/GlobalStateExplorers/FLEXWebViewController.m`
- Enhanced `viewDidLoad` with title-based identifier assignment
- Content moved from identifier to `accessibilityValue` for proper semantic structure
- Supports both request and response body differentiation

## Technical Approach
- **Minimal Impact**: Uses only conventional UIKit accessibility properties
- **No Dependencies**: No additional frameworks or complex observers required
- **Standard Patterns**: Follows iOS accessibility best practices
- **Backward Compatible**: Changes don't affect existing functionality

## Testing
Automation scripts can now:
```swift
// Select specific network calls
app.cells["network_call_0"].tap()

// Access request/response content
let requestBody = app.webViews["network_request_body"]
let content = requestBody.value as? String