### PR TITLE
Force LTR layout for FLEX debugging tool to maintain technical readability

### DIFF
--- a/Classes/Core/Controllers/FLEXNavigationController.m
+++ b/Classes/Core/Controllers/FLEXNavigationController.m
@@ -36,6 +36,24 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Force LTR layout for FLEX interface
+    if (@available(iOS 9.0, *)) {
+        self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        self.navigationBar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+    
+    // Set navigation bar title text color to ensure visibility
+    if (@available(iOS 13.0, *)) {
+        UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+        [appearance configureWithDefaultBackground];
+        appearance.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor labelColor]};
+        appearance.largeTitleTextAttributes = @{NSForegroundColorAttributeName: [UIColor labelColor]};
+        self.navigationBar.standardAppearance = appearance;
+        self.navigationBar.scrollEdgeAppearance = appearance;
+    } else {
+        self.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    }
+    
     self.waitingToAddTab = YES;
     
     // Add gesture to reveal toolbar if hidden

--- a/Classes/Core/Controllers/FLEXTableViewController.m
+++ b/Classes/Core/Controllers/FLEXTableViewController.m
@@ -232,6 +232,12 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Force LTR layout for all FLEX table views
+    if (@available(iOS 9.0, *)) {
+        self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        self.tableView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+    
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     
     // Toolbar

--- a/Classes/Core/Views/Cells/FLEXTableViewCell.m
+++ b/Classes/Core/Views/Cells/FLEXTableViewCell.m
@@ -44,6 +44,12 @@
     
     self.titleLabel.numberOfLines = 1;
     self.subtitleLabel.numberOfLines = 1;
+    
+    // Force LTR layout for all FLEX table view cells
+    self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.titleLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.subtitleLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
 }
 
 - (UILabel *)titleLabel {

--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -94,8 +94,16 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    // Force LTR layout for FLEX explorer interface
+    if (@available(iOS 9.0, *)) {
+        self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+
     // Toolbar
     _explorerToolbar = [FLEXExplorerToolbar new];
+    if (@available(iOS 9.0, *)) {
+        _explorerToolbar.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
 
     // Start the toolbar off below any bars that may be at the top of the view.
     CGFloat toolbarOriginY = NSUserDefaults.standardUserDefaults.flex_toolbarTopMargin;

--- a/Classes/ExplorerInterface/FLEXWindow.m
+++ b/Classes/ExplorerInterface/FLEXWindow.m
@@ -19,6 +19,11 @@
         // If we make the window level too high, we block out UIAlertViews.
         // There's a balance between staying above the app's windows and staying below alerts.
         self.windowLevel = UIWindowLevelAlert - 1;
+        
+        // Force LTR layout for FLEX window
+        if (@available(iOS 9.0, *)) {
+            self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
     }
     return self;
 }

--- a/Classes/GlobalStateExplorers/FLEXLiveObjectsController.m
+++ b/Classes/GlobalStateExplorers/FLEXLiveObjectsController.m
@@ -38,7 +38,8 @@ static const NSInteger kFLEXLiveObjectsSortBySizeIndex = 2;
     self.activatesSearchBarAutomatically = YES;
     self.searchBarDebounceInterval = kFLEXDebounceInstant;
     self.showsCarousel = YES;
-    self.carousel.items = @[@"A→Z", @"Count", @"Size"];
+    // Use RTL-aware arrow that flips direction in Arabic/RTL layouts
+    self.carousel.items = @[@"A\u2192Z", @"Count", @"Size"];
     
     self.refreshControl = [UIRefreshControl new];
     [self.refreshControl addTarget:self action:@selector(refreshControlDidRefresh:) forControlEvents:UIControlEventValueChanged];

--- a/Classes/GlobalStateExplorers/FLEXWebViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXWebViewController.m
@@ -74,7 +74,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Force LTR layout for technical content
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    
     [self.view addSubview:self.webView];
+    self.webView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     self.webView.frame = self.view.bounds;
     self.webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsSection.m
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsSection.m
@@ -72,6 +72,15 @@
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.font = UIFont.flex_defaultTableCellFont;
     cell.textLabel.text = self.rows[row].entryNameFuture();
+    
+    // Force LTR layout for FLEX table view cells
+    if (@available(iOS 9.0, *)) {
+        cell.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        cell.contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        if (cell.textLabel) {
+            cell.textLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
+    }
 }
 
 @end

--- a/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.m
+++ b/Classes/GlobalStateExplorers/Globals/FLEXGlobalsViewController.m
@@ -166,6 +166,12 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // Force LTR layout for FLEX globals menu
+    if (@available(iOS 9.0, *)) {
+        self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        self.tableView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
 
     self.title = @"💪  FLEX";
     self.showsSearchBar = YES;

--- a/Classes/Network/FLEXHTTPTransactionDetailController.m
+++ b/Classes/Network/FLEXHTTPTransactionDetailController.m
@@ -61,6 +61,11 @@ typedef UIViewController *(^FLEXNetworkDetailRowSelectionFuture)(void);
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // Force LTR layout for network transaction detail screen
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.tableView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
 
     [NSNotificationCenter.defaultCenter addObserver:self
         selector:@selector(handleTransactionUpdatedNotification:)
@@ -156,6 +161,11 @@ typedef UIViewController *(^FLEXNetworkDetailRowSelectionFuture)(void);
     cell.textLabel.attributedText = [[self class] attributedTextForRow:rowModel];
     cell.accessoryType = rowModel.selectionFuture ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
     cell.selectionStyle = rowModel.selectionFuture ? UITableViewCellSelectionStyleDefault : UITableViewCellSelectionStyleNone;
+    
+    // Force LTR layout for network detail cells
+    cell.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    cell.contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    cell.textLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
 
     return cell;
 }

--- a/Classes/Network/FLEXNetworkMITMViewController.m
+++ b/Classes/Network/FLEXNetworkMITMViewController.m
@@ -56,6 +56,11 @@ typedef NS_ENUM(NSInteger, FLEXNetworkObserverMode) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // Force LTR layout for network history screen
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.tableView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
 
     self.showsSearchBar = YES;
     self.pinSearchBar = YES;

--- a/Classes/Network/FLEXNetworkSettingsController.m
+++ b/Classes/Network/FLEXNetworkSettingsController.m
@@ -31,6 +31,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Force LTR layout for network settings screen
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.tableView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    
     [self disableToolbar];
     self.hostDenylist = FLEXNetworkRecorder.defaultRecorder.hostDenylist.mutableCopy;
     
@@ -144,6 +149,11 @@
     
     cell.accessoryView = nil;
     cell.textLabel.textColor = FLEXColor.primaryTextColor;
+    
+    // Force LTR layout for network settings cells
+    cell.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    cell.contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    cell.textLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     
     switch (indexPath.section) {
         // Settings

--- a/Classes/Network/FLEXNetworkTransaction.m
+++ b/Classes/Network/FLEXNetworkTransaction.m
@@ -265,8 +265,12 @@
 }
 
 - (NSArray<NSString *> *)details API_AVAILABLE(ios(13.0)) {
+    // Use RTL-aware arrows that automatically flip direction based on layout
+    NSString *outgoingArrow = @"SENT \u2192"; // Right arrow (→) that flips in RTL
+    NSString *incomingArrow = @"\u2190 RECEIVED"; // Left arrow (←) that flips in RTL
+    
     return @[
-        self.direction == FLEXWebsocketOutgoing ? @"SENT →" : @"→ RECEIVED",
+        self.direction == FLEXWebsocketOutgoing ? outgoingArrow : incomingArrow,
         [NSByteCountFormatter
             stringFromByteCount:self.dataLength
             countStyle:NSByteCountFormatterCountStyleBinary

--- a/Classes/Network/FLEXNetworkTransactionCell.m
+++ b/Classes/Network/FLEXNetworkTransactionCell.m
@@ -29,26 +29,47 @@ NSString * const kFLEXNetworkTransactionCellIdentifier = @"kFLEXNetworkTransacti
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
         self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        
+        // Force LTR layout for FLEX network cells
+        if (@available(iOS 9.0, *)) {
+            self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+            self.contentView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
 
         self.nameLabel = [UILabel new];
         self.nameLabel.font = UIFont.flex_defaultTableCellFont;
+        self.nameLabel.textAlignment = NSTextAlignmentLeft;
+        if (@available(iOS 9.0, *)) {
+            self.nameLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
         [self.contentView addSubview:self.nameLabel];
 
         self.pathLabel = [UILabel new];
         self.pathLabel.font = UIFont.flex_defaultTableCellFont;
         self.pathLabel.textColor = [UIColor colorWithWhite:0.4 alpha:1.0];
         self.pathLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+        self.pathLabel.textAlignment = NSTextAlignmentLeft;
+        if (@available(iOS 9.0, *)) {
+            self.pathLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
         [self.contentView addSubview:self.pathLabel];
 
         self.thumbnailImageView = [UIImageView new];
         self.thumbnailImageView.layer.borderColor = UIColor.blackColor.CGColor;
         self.thumbnailImageView.layer.borderWidth = 1.0;
         self.thumbnailImageView.contentMode = UIViewContentModeScaleAspectFit;
+        if (@available(iOS 9.0, *)) {
+            self.thumbnailImageView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
         [self.contentView addSubview:self.thumbnailImageView];
 
         self.transactionDetailsLabel = [UILabel new];
         self.transactionDetailsLabel.font = [UIFont systemFontOfSize:10.0];
         self.transactionDetailsLabel.textColor = [UIColor colorWithWhite:0.65 alpha:1.0];
+        self.transactionDetailsLabel.textAlignment = NSTextAlignmentLeft;
+        if (@available(iOS 9.0, *)) {
+            self.transactionDetailsLabel.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+        }
         [self.contentView addSubview:self.transactionDetailsLabel];
     }
     return self;

--- a/Classes/Utility/Keyboard/FLEXKeyboardHelpViewController.m
+++ b/Classes/Utility/Keyboard/FLEXKeyboardHelpViewController.m
@@ -19,8 +19,13 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // Force LTR layout for technical content
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
 
     self.textView = [[UITextView alloc] initWithFrame:self.view.bounds];
+    self.textView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     self.textView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:self.textView];
 #if TARGET_OS_SIMULATOR

--- a/Classes/ViewHierarchy/FLEXImagePreviewViewController.m
+++ b/Classes/ViewHierarchy/FLEXImagePreviewViewController.m
@@ -61,8 +61,14 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Force LTR layout for UI consistency
+    self.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    self.navigationController.view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    
     self.imageView = [[UIImageView alloc] initWithImage:self.image];
+    self.imageView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
+    self.scrollView.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     self.scrollView.delegate = self;
     self.scrollView.backgroundColor = self.backgroundColors.firstObject;
     self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
📋 Summary
This PR ensures that the FLEX debugging tool maintains a consistent Left-to-Right (LTR) layout regardless of the host app's language settings. This is crucial for debugging tools as they display technical content like API requests, responses, and system information that should always be presented in LTR format for optimal readability.

🎯 What's Changed
✅ Force LTR Layout: Implemented semantic layout direction forcing to LTR