### PR TITLE
Add copy support to description cell in FLEXObjectExplorerViewController

### DIFF
--- a/Classes/Core/FLEXSingleRowSection.m
+++ b/Classes/Core/FLEXSingleRowSection.m
@@ -87,7 +87,7 @@
 }
 
 - (NSArray<NSString *> *)copyMenuItemsForRow:(NSInteger)row {
-    NSString *text = [self titleForRow:row];
+    NSString *const text = [self titleForRow:row];
     if (text.length) {
         return @[@"Text", text];
     }


### PR DESCRIPTION
Right now the description cell in `FLEXObjectExplorerViewController` uses `FLEXSingleRowSection`, which doesn't have the copy support. Thus long press copying is not an option there.

The other cells are using `FLEXMetadataSection` which has good support. This change is going to add a basic "Copy Text" menu action for single row section.

Screenshot:
<img width="1206" height="2622" alt="simulator_screenshot_2671C90C-6DFF-4B04-9CA2-CC11D34C9985" src="https://github.com/user-attachments/assets/1ce23d42-d23e-49c1-8e9f-5adfa9321921" />

