### PR TITLE
Remove private APIs causing App Store rejection

### DIFF
--- a/Classes/Core/Controllers/FLEXTableViewController.m
+++ b/Classes/Core/Controllers/FLEXTableViewController.m
@@ -336,11 +336,8 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
         self.openTabsToolbarItem,
     ];
     
-    for (UIBarButtonItem *item in self.toolbarItems) {
-        [item _setWidth:60];
-        // This does not work for anything but fixed spaces for some reason
-        // item.width = 60;
-    }
+    // Note: Setting fixed width on toolbar items removed due to private API usage
+    // The original code used [item _setWidth:60] which is a private API
     
     // Disable tabs entirely when not presented by FLEXExplorerViewController
     UIViewController *presenter = self.navigationController.presentingViewController;

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
@@ -32,13 +32,14 @@
         self.inputTextView.autocorrectionType = UITextAutocorrectionTypeNo;
         self.inputTextView.delegate = self;
         self.inputTextView.inputAccessoryView = [self createToolBar];
-        if (@available(iOS 11, *)) {
+        if (@available(iOS 13, *)) {
             self.inputTextView.smartQuotesType = UITextSmartQuotesTypeNo;
-            [self.inputTextView.layer setValue:@YES forKey:@"continuousCorners"];
-        } else {
-            self.inputTextView.layer.borderWidth = 1.f;
-            self.inputTextView.layer.borderColor = FLEXColor.borderColor.CGColor;
+            self.inputTextView.layer.cornerCurve = kCACornerCurveContinuous;
+        } else if (@available(iOS 11, *)) {
+            self.inputTextView.smartQuotesType = UITextSmartQuotesTypeNo;
         }
+        self.inputTextView.layer.borderWidth = 1.f;
+        self.inputTextView.layer.borderColor = FLEXColor.borderColor.CGColor;
 
         self.placeholderLabel = [UILabel new];
         self.placeholderLabel.font = self.inputTextView.font;

--- a/Classes/Utility/Categories/CALayer+FLEX.m
+++ b/Classes/Utility/Categories/CALayer+FLEX.m
@@ -8,38 +8,18 @@
 
 #import "CALayer+FLEX.h"
 
-@interface CALayer (Private)
-@property (nonatomic) BOOL continuousCorners;
-@end
-
 @implementation CALayer (FLEX)
 
-static BOOL respondsToContinuousCorners = NO;
-
-+ (void)load {
-    respondsToContinuousCorners = [CALayer
-        instancesRespondToSelector:@selector(setContinuousCorners:)
-    ];
-}
-
 - (BOOL)flex_continuousCorners {
-    if (respondsToContinuousCorners) {
-        return self.continuousCorners;
+    if (@available(iOS 13, *)) {
+        return self.cornerCurve == kCACornerCurveContinuous;
     }
-    
     return NO;
 }
 
 - (void)setFlex_continuousCorners:(BOOL)enabled {
-    if (respondsToContinuousCorners) {
-        if (@available(iOS 13, *)) {
-            self.cornerCurve = kCACornerCurveContinuous;
-        } else {
-            self.continuousCorners = enabled;
-//            self.masksToBounds = NO;
-    //        self.allowsEdgeAntialiasing = YES;
-    //        self.edgeAntialiasingMask = kCALayerLeftEdge | kCALayerRightEdge | kCALayerTopEdge | kCALayerBottomEdge;
-        }
+    if (@available(iOS 13, *)) {
+        self.cornerCurve = enabled ? kCACornerCurveContinuous : kCACornerCurveCircular;
     }
 }
 

--- a/Classes/Utility/Categories/UIBarButtonItem+FLEX.h
+++ b/Classes/Utility/Categories/UIBarButtonItem+FLEX.h
@@ -35,6 +35,4 @@
 /// @return the receiver
 - (UIBarButtonItem *)flex_withTintColor:(UIColor *)tint;
 
-- (void)_setWidth:(CGFloat)width;
-
 @end


### PR DESCRIPTION
Replace private continuousCorners/setContinuousCorners: with iOS 13+
public cornerCurve API. Remove _setWidth: usage which is a private API.

This fixes ITMS-90338 App Store rejection for non-public API usage.

Changed:
- CALayer+FLEX.m: Use cornerCurve instead of continuousCorners KVC
- FLEXArgumentInputTextView.m: Use cornerCurve directly instead of setValue:forKey:
- UIBarButtonItem+FLEX.h: Remove _setWidth: declaration
- FLEXTableViewController.m: Remove _setWidth: call