### PR TITLE
Replace deprecated UIScreen.mainScreen in FLEXMacros.h

### DIFF
--- a/Classes/Utility/FLEXMacros.h
+++ b/Classes/Utility/FLEXMacros.h
@@ -40,14 +40,35 @@ extern BOOL FLEXConstructorsShouldRun(void);
 /// A macro to return from the current procedure if we don't want to run constructors
 #define FLEX_EXIT_IF_NO_CTORS() if (!FLEXConstructorsShouldRun()) return;
 
+/// Returns a UIScreen instance found through the application's scene context,
+/// since +[UIScreen mainScreen] is deprecated in iOS 26.
+NS_INLINE UIScreen *FLEXScreen(void) {
+    UIScreen *fallback = nil;
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIScreen *screen = ((UIWindowScene *)scene).screen;
+            if (scene.activationState == UISceneActivationStateForegroundActive) {
+                return screen;
+            }
+            if (!fallback) fallback = screen;
+        }
+    }
+    if (fallback) return fallback;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return UIScreen.mainScreen;
+#pragma clang diagnostic pop
+}
+
 /// Rounds down to the nearest "point" coordinate
 NS_INLINE CGFloat FLEXFloor(CGFloat x) {
-    return floor(UIScreen.mainScreen.scale * (x)) / UIScreen.mainScreen.scale;
+    CGFloat scale = FLEXScreen().scale;
+    return floor(scale * (x)) / scale;
 }
 
 /// Returns the given number of points in pixels
 NS_INLINE CGFloat FLEXPointsToPixels(CGFloat points) {
-    return points / UIScreen.mainScreen.scale;
+    return points / FLEXScreen().scale;
 }
 
 /// Creates a CGRect with all members rounded down to the nearest "point" coordinate

--- a/Classes/Utility/FLEXMacros.h
+++ b/Classes/Utility/FLEXMacros.h
@@ -50,10 +50,14 @@ NS_INLINE UIScreen *FLEXScreen(void) {
             if (scene.activationState == UISceneActivationStateForegroundActive) {
                 return screen;
             }
-            if (!fallback) fallback = screen;
+            if (!fallback) {
+                fallback = screen;
+            }
         }
     }
-    if (fallback) return fallback;
+    if (fallback) {
+        return fallback;
+    }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return UIScreen.mainScreen;

--- a/Classes/Utility/FLEXMacros.h
+++ b/Classes/Utility/FLEXMacros.h
@@ -41,22 +41,26 @@ extern BOOL FLEXConstructorsShouldRun(void);
 #define FLEX_EXIT_IF_NO_CTORS() if (!FLEXConstructorsShouldRun()) return;
 
 /// Returns a UIScreen instance found through the application's scene context,
-/// since +[UIScreen mainScreen] is deprecated in iOS 26.
+/// since +[UIScreen mainScreen] is deprecated in iOS 26. Falls back to
+/// +[UIScreen mainScreen] on iOS < 13, where scenes are unavailable and
+/// +mainScreen is not yet deprecated.
 NS_INLINE UIScreen *FLEXScreen(void) {
-    UIScreen *fallback = nil;
-    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
-        if ([scene isKindOfClass:[UIWindowScene class]]) {
-            UIScreen *screen = ((UIWindowScene *)scene).screen;
-            if (scene.activationState == UISceneActivationStateForegroundActive) {
-                return screen;
-            }
-            if (!fallback) {
-                fallback = screen;
+    if (@available(iOS 13.0, *)) {
+        UIScreen *fallback = nil;
+        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                UIScreen *screen = ((UIWindowScene *)scene).screen;
+                if (scene.activationState == UISceneActivationStateForegroundActive) {
+                    return screen;
+                }
+                if (!fallback) {
+                    fallback = screen;
+                }
             }
         }
-    }
-    if (fallback) {
-        return fallback;
+        if (fallback) {
+            return fallback;
+        }
     }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Adds a `FLEXScreen()` helper that resolves a `UIScreen` instance through the application's connected scene context, preferring the foreground-active window scene. `UIScreen.mainScreen` is deprecated in iOS 26.

<img width="522" height="188" alt="Screenshot 2026-04-27 at 3 23 58 PM" src="https://github.com/user-attachments/assets/ecfc6d63-dd09-4d77-be81-26aa8148f735" />
